### PR TITLE
Fix Claude hooks installation to match Claude Code's expected JSON structure

### DIFF
--- a/lib/claude/hooks.ex
+++ b/lib/claude/hooks.ex
@@ -134,28 +134,77 @@ defmodule Claude.Hooks do
 
   defp add_all_hooks do
     Settings.update(fn settings ->
+      # Ensure settings has the root "hooks" object
+      settings = Map.put_new(settings, "hooks", %{})
+
       # First remove any existing Claude hooks to ensure clean installation
       claude_commands = Enum.map(@hooks, fn hook -> hook.config().command end)
       settings = remove_claude_hooks_from_settings(settings, claude_commands)
 
-      # Group hooks by event type
-      hooks_by_event =
+      # Group hooks by event type and matcher
+      hooks_by_event_and_matcher =
         @hooks
         |> Enum.group_by(fn hook_module ->
           # Extract event type from module name (e.g., PostToolUse)
-          hook_module
-          |> Module.split()
-          |> Enum.at(2)
+          event_type =
+            hook_module
+            |> Module.split()
+            |> Enum.at(2)
+
+          # Get the matcher from the hook config
+          matcher = hook_module.config().matcher
+
+          {event_type, matcher}
         end)
 
-      Enum.reduce(hooks_by_event, settings, fn {event_type, hook_modules}, acc ->
-        hook_configs = Enum.map(hook_modules, fn hook_module -> hook_module.config() end)
+      # Build the new structure
+      updated_hooks = get_in(settings, ["hooks"]) || %{}
 
-        existing_hooks = get_in(acc, [event_type, "hooks"]) || []
-        updated_hooks = existing_hooks ++ hook_configs
+      new_hooks =
+        Enum.reduce(hooks_by_event_and_matcher, updated_hooks, fn {{event_type, matcher},
+                                                                   hook_modules},
+                                                                  acc ->
+          # Get existing matchers for this event type
+          existing_matchers = Map.get(acc, event_type, [])
 
-        put_in(acc, [event_type], %{"hooks" => updated_hooks})
-      end)
+          # Find if we already have a matcher object for this pattern
+          matcher_index =
+            Enum.find_index(existing_matchers, fn m ->
+              Map.get(m, "matcher") == matcher
+            end)
+
+          # Create hook configs without the matcher field
+          hook_configs =
+            Enum.map(hook_modules, fn hook_module ->
+              config = hook_module.config()
+
+              %{
+                "type" => config.type,
+                "command" => config.command
+              }
+            end)
+
+          if matcher_index do
+            # Update existing matcher object
+            updated_matchers =
+              List.update_at(existing_matchers, matcher_index, fn matcher_obj ->
+                existing_hooks = Map.get(matcher_obj, "hooks", [])
+                Map.put(matcher_obj, "hooks", existing_hooks ++ hook_configs)
+              end)
+
+            Map.put(acc, event_type, updated_matchers)
+          else
+            # Create new matcher object
+            new_matcher_obj = %{
+              "matcher" => matcher,
+              "hooks" => hook_configs
+            }
+
+            Map.put(acc, event_type, existing_matchers ++ [new_matcher_obj])
+          end
+        end)
+
+      Map.put(settings, "hooks", new_hooks)
     end)
   end
 
@@ -173,27 +222,47 @@ defmodule Claude.Hooks do
   end
 
   defp remove_claude_hooks_from_settings(settings, claude_commands) do
-    settings
-    |> Enum.map(fn {event_type, event_config} ->
-      case event_config do
-        %{"hooks" => hooks} when is_list(hooks) ->
-          filtered_hooks =
-            hooks
-            |> Enum.reject(fn hook ->
-              hook["command"] in claude_commands
-            end)
+    hooks = Map.get(settings, "hooks", %{})
 
-          if filtered_hooks == [] do
+    updated_hooks =
+      hooks
+      |> Enum.map(fn
+        {event_type, matchers} when is_list(matchers) ->
+          updated_matchers =
+            matchers
+            |> Enum.map(fn matcher_obj ->
+              hooks_list = Map.get(matcher_obj, "hooks", [])
+
+              filtered_hooks =
+                hooks_list
+                |> Enum.reject(fn hook ->
+                  Map.get(hook, "command") in claude_commands
+                end)
+
+              if filtered_hooks == [] do
+                :remove
+              else
+                Map.put(matcher_obj, "hooks", filtered_hooks)
+              end
+            end)
+            |> Enum.reject(&(&1 == :remove))
+
+          if updated_matchers == [] do
             {event_type, :remove}
           else
-            {event_type, %{"hooks" => filtered_hooks}}
+            {event_type, updated_matchers}
           end
 
-        _ ->
-          {event_type, event_config}
-      end
-    end)
-    |> Enum.reject(fn {_, value} -> value == :remove end)
-    |> Map.new()
+        {event_type, other} ->
+          {event_type, other}
+      end)
+      |> Enum.reject(fn {_, value} -> value == :remove end)
+      |> Map.new()
+
+    if updated_hooks == %{} do
+      Map.delete(settings, "hooks")
+    else
+      Map.put(settings, "hooks", updated_hooks)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fixed the hooks installation to generate the correct JSON structure that Claude Code expects
- Updated tests using TDD approach to verify the fix
- Ensures compatibility with Claude Code's hooks documentation

## Problem
The `mix claude.install` command was generating an incorrect JSON structure that didn't match Claude Code's expected format. The generated structure had:
- Missing root `"hooks"` object
- `PostToolUse` as a direct object instead of an array of matcher objects
- Individual hooks containing the `"matcher"` field instead of the matcher object

## Solution
Updated the hooks installation logic to generate the correct structure:
```json
{
  "hooks": {
    "PostToolUse": [
      {
        "matcher": ".*",
        "hooks": [
          {
            "command": "...",
            "type": "command"
          }
        ]
      }
    ]
  }
}
```

## Test plan
- [x] Updated tests to expect the correct structure
- [x] Verified tests failed with old implementation
- [x] Updated implementation to make tests pass
- [x] Manually tested `mix claude.install` to verify correct output
- [x] Verified that `mix claude.uninstall` properly removes hooks

🤖 Generated with [Claude Code](https://claude.ai/code)