### PR TITLE
Fix UndefinedFunctionError for supports_umbrella? in Igniter tasks

### DIFF
--- a/lib/mix/tasks/claude.hooks.install.ex
+++ b/lib/mix/tasks/claude.hooks.install.ex
@@ -68,4 +68,7 @@ defmodule Mix.Tasks.Claude.Hooks.Install do
     #{Installer.format_hooks_list()}
     """)
   end
+
+  @impl Igniter.Mix.Task
+  def supports_umbrella?, do: false
 end

--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -38,6 +38,9 @@ if Code.ensure_loaded?(Igniter) do
       igniter
       |> Igniter.compose_task("claude.hooks.install", [])
     end
+
+    @impl Igniter.Mix.Task
+    def supports_umbrella?, do: false
   end
 else
   defmodule Mix.Tasks.Claude.Install do


### PR DESCRIPTION
## Summary
- Adds the required `supports_umbrella?/0` callback to both Igniter tasks
- Fixes the error when running `mix igniter.install claude` in other projects

## Problem
When running `mix igniter.install claude` in another project, users would encounter:
```
** (UndefinedFunctionError) function Mix.Tasks.Claude.Install.supports_umbrella?/0 is undefined or private
```

This occurred because Igniter requires all tasks using `Igniter.Mix.Task` to implement the `supports_umbrella?/0` callback.

## Solution
Added the `supports_umbrella?/0` callback to both:
- `Mix.Tasks.Claude.Install` 
- `Mix.Tasks.Claude.Hooks.Install`

Both return `false` since Claude hooks are installed per-project, not at the umbrella root level.

## Test plan
- [x] Run `mix compile --warnings-as-errors` - passes
- [x] Run `mix test` - all tests pass
- [ ] Test `mix igniter.install claude` in another project

🤖 Generated with [Claude Code](https://claude.ai/code)