### PR TITLE
Remove .claude from gitignore to track Claude configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,3 @@ claude-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
-
-# Claude configuration directory (user-specific)
-.claude/


### PR DESCRIPTION
## Summary
- Removes `.claude/` from gitignore to allow tracking of Claude hooks configuration
- Enables team-wide sharing of automatic formatting and compilation checking settings

## Test plan
- [x] Verify .gitignore no longer excludes .claude directory
- [ ] Confirm Claude hooks still function correctly after change
- [ ] Ensure .claude/settings.json can be committed to the repository

🤖 Generated with [Claude Code](https://claude.ai/code)