### PR TITLE
Add test running to pre-commit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Pre-commit hook now validates for unused dependencies in mix.lock
+- Pre-commit hook now runs tests before allowing commits
 - Automatic `usage_rules` integration in igniter install process:
 
 ## [0.1.0] - 2025-07-25


### PR DESCRIPTION
## Summary
- Integrated test execution into the existing pre-commit validation flow
- Tests now run as the final validation step after formatting, compilation, and dependency checks
- Added comprehensive test coverage for the new functionality

## Changes
- Modified `Claude.Hooks.PreToolUse.PreCommitCheck` to include a `run_tests/0` function
- Updated module documentation and description to reflect test validation
- Added unit and integration tests for the new test-running functionality
- Removed the separate TestRunner module in favor of integrating directly into the existing hook

## Test plan
- [x] Run `mix test` - all tests pass
- [x] Test the pre-commit hook manually with passing tests
- [x] Test the pre-commit hook manually with failing tests
- [x] Verify hook blocks commits when tests fail
- [x] Verify hook allows commits when all validations pass

🤖 Generated with [Claude Code](https://claude.ai/code)