### PR TITLE
Add idiomatic Elixir structs for Claude Code hook events

### DIFF
--- a/lib/claude/core/json_utils.ex
+++ b/lib/claude/core/json_utils.ex
@@ -1,0 +1,28 @@
+defmodule Claude.Core.JsonUtils do
+  @moduledoc """
+  Utilities for converting between Elixir snake_case and JSON camelCase.
+  """
+
+  @doc """
+  Converts a map with snake_case keys to camelCase keys recursively.
+  """
+  def to_camel_case(map) when is_map(map) do
+    Map.new(map, fn {k, v} ->
+      key = k |> to_string() |> camelize()
+      value = if is_map(v), do: to_camel_case(v), else: v
+      {key, value}
+    end)
+  end
+
+  @doc """
+  Converts a snake_case string to camelCase.
+  """
+  def camelize(string) do
+    case String.split(string, "_") do
+      [head | tail] ->
+        head <> Enum.map_join(tail, "", &String.capitalize/1)
+      [] ->
+        string
+    end
+  end
+end

--- a/lib/claude/hooks/events.ex
+++ b/lib/claude/hooks/events.ex
@@ -1,0 +1,41 @@
+defmodule Claude.Hooks.Events do
+  @moduledoc """
+  Hook event structures for Claude Code.
+
+  This module serves as the main entry point for all hook event types.
+  Each event type has its own module with Input and Output structures
+  where applicable.
+
+  ## Event Types
+
+  - `PreToolUse` - Before tool execution
+  - `PostToolUse` - After tool execution  
+  - `Notification` - Claude notifications
+  - `UserPromptSubmit` - User prompt submission
+  - `Stop` - Main agent stopping
+  - `SubagentStop` - Sub-agent stopping
+  - `PreCompact` - Before compaction
+
+  ## Common Functions
+
+  Use `Claude.Hooks.Events.Common.parse_hook_input/1` to parse incoming
+  JSON into the appropriate event struct.
+
+  Use `Claude.Hooks.Events.Common.SimpleOutput` for basic exit code
+  based responses.
+
+  ## Example
+
+      alias Claude.Hooks.Events
+      alias Claude.Hooks.Events.Common
+      
+      # Parse incoming hook
+      case Common.parse_hook_input(json) do
+        {:ok, %Events.PreToolUse.Input{tool_name: "Bash"}} ->
+          # Handle bash command
+          
+        {:ok, event} ->
+          # Handle other events
+      end
+  """
+end

--- a/lib/claude/hooks/events/common.ex
+++ b/lib/claude/hooks/events/common.ex
@@ -1,0 +1,106 @@
+defmodule Claude.Hooks.Events.Common do
+  @moduledoc """
+  Common functionality shared across all hook events.
+  """
+
+  alias Claude.Hooks.Events.{
+    PreToolUse,
+    PostToolUse,
+    Notification,
+    UserPromptSubmit,
+    Stop,
+    SubagentStop,
+    PreCompact
+  }
+
+  @doc """
+  Parses a JSON input into the appropriate hook event struct based on hook_event_name.
+
+  ## Examples
+
+      iex> json = ~s({"hook_event_name": "PreToolUse", "tool_name": "Edit", "session_id": "123"})
+      iex> {:ok, event} = Claude.Hooks.Events.Common.parse_hook_input(json)
+      iex> match?(%Claude.Hooks.Events.PreToolUse.Input{}, event)
+      true
+  """
+  def parse_hook_input(json) when is_binary(json) do
+    with {:ok, data} <- Jason.decode(json) do
+      case data["hook_event_name"] do
+        "PreToolUse" -> {:ok, PreToolUse.Input.new(data)}
+        "PostToolUse" -> {:ok, PostToolUse.Input.new(data)}
+        "Notification" -> {:ok, Notification.Input.new(data)}
+        "UserPromptSubmit" -> {:ok, UserPromptSubmit.Input.new(data)}
+        "Stop" -> {:ok, Stop.Input.new(data)}
+        "SubagentStop" -> {:ok, SubagentStop.Input.new(data)}
+        "PreCompact" -> {:ok, PreCompact.Input.new(data)}
+        other -> {:error, "Unknown hook event name: #{inspect(other)}"}
+      end
+    end
+  end
+
+  def parse_hook_input(_), do: {:error, "Input must be a JSON string"}
+
+  defmodule SimpleOutput do
+    @moduledoc """
+    Represents simple hook output using exit codes and stdout/stderr.
+
+    Exit codes:
+    - 0: Success, stdout shown to user (except UserPromptSubmit where it's added as context)
+    - 2: Blocking error, stderr shown to Claude
+    - Other: Non-blocking error, stderr shown to user
+    """
+    defstruct exit_code: 0,
+              stdout: nil,
+              stderr: nil
+
+    @type t :: %__MODULE__{
+            exit_code: non_neg_integer(),
+            stdout: String.t() | nil,
+            stderr: String.t() | nil
+          }
+
+    @doc """
+    Creates a success output with optional stdout.
+    """
+    def success(stdout \\ nil) do
+      %__MODULE__{exit_code: 0, stdout: stdout}
+    end
+
+    @doc """
+    Creates a blocking error output with stderr message.
+    """
+    def block(stderr) do
+      %__MODULE__{exit_code: 2, stderr: stderr}
+    end
+
+    @doc """
+    Creates a non-blocking error output with stderr message.
+    """
+    def error(stderr, exit_code \\ 1) when exit_code != 0 and exit_code != 2 do
+      %__MODULE__{exit_code: exit_code, stderr: stderr}
+    end
+
+
+    @doc """
+    Writes the output to appropriate streams and exits with the code.
+    """
+    def write_and_exit(%__MODULE__{} = output) do
+      if output.stdout, do: IO.puts(output.stdout)
+      if output.stderr, do: IO.puts(:stderr, output.stderr)
+      System.halt(output.exit_code)
+    end
+  end
+
+  defimpl Jason.Encoder, for: SimpleOutput do
+    alias Claude.Core.JsonUtils
+
+    def encode(%SimpleOutput{} = output, opts) do
+      output
+      |> Map.from_struct()
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+      |> JsonUtils.to_camel_case()
+      |> Jason.Encode.map(opts)
+    end
+  end
+end

--- a/lib/claude/hooks/events/notification.ex
+++ b/lib/claude/hooks/events/notification.ex
@@ -1,0 +1,55 @@
+defmodule Claude.Hooks.Events.Notification do
+  @moduledoc """
+  Notification hook event structures.
+
+  Runs when Claude Code sends notifications, such as permission requests
+  or idle prompts.
+  """
+
+  defmodule Input do
+    @moduledoc """
+    Input data for Notification hook events.
+    """
+    @derive Jason.Encoder
+    defstruct [:session_id, :transcript_path, :cwd, :hook_event_name, :message]
+
+    @type t :: %__MODULE__{
+            session_id: String.t(),
+            transcript_path: String.t(),
+            cwd: String.t(),
+            hook_event_name: String.t(),
+            message: String.t()
+          }
+
+    @doc """
+    Creates a new Notification Input struct from a map.
+    """
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        session_id: attrs["session_id"],
+        transcript_path: attrs["transcript_path"],
+        cwd: attrs["cwd"],
+        hook_event_name: attrs["hook_event_name"] || "Notification",
+        message: attrs["message"]
+      }
+    end
+
+    @doc """
+    Parses JSON string into Notification Input struct.
+    """
+    def from_json(json) when is_binary(json) do
+      case Jason.decode(json) do
+        {:ok, data} -> {:ok, new(data)}
+        {:error, _} = error -> error
+      end
+    end
+  end
+
+  # Notification hooks typically use SimpleOutput or basic exit codes
+  # No specific output structure needed
+  defmodule Output do
+    defdelegate success(stdout \\ nil), to: Claude.Hooks.Events.Common.SimpleOutput
+    defdelegate error(stderr, exit_code \\ 1), to: Claude.Hooks.Events.Common.SimpleOutput
+    defdelegate block(stderr), to: Claude.Hooks.Events.Common.SimpleOutput
+  end
+end

--- a/lib/claude/hooks/events/post_tool_use.ex
+++ b/lib/claude/hooks/events/post_tool_use.ex
@@ -1,0 +1,139 @@
+defmodule Claude.Hooks.Events.PostToolUse do
+  @moduledoc """
+  PostToolUse hook event structures.
+
+  Runs immediately after a tool completes successfully.
+  """
+
+  alias Claude.Hooks.ToolInputs
+  alias Claude.Core.JsonUtils
+
+  defmodule Input do
+    @moduledoc """
+    Input data for PostToolUse hook events.
+    """
+    @derive Jason.Encoder
+    defstruct [
+      :session_id,
+      :transcript_path,
+      :cwd,
+      :hook_event_name,
+      :tool_name,
+      :tool_input,
+      :tool_response
+    ]
+
+    @type t :: %__MODULE__{
+            session_id: String.t(),
+            transcript_path: String.t(),
+            cwd: String.t(),
+            hook_event_name: String.t(),
+            tool_name: String.t(),
+            tool_input: map() | struct(),
+            tool_response: map()
+          }
+
+    @doc """
+    Creates a new PostToolUse Input struct from a map.
+
+    The tool_input field will be parsed into the appropriate tool-specific struct
+    based on the tool_name.
+    """
+    def new(attrs) when is_map(attrs) do
+      tool_name = attrs["tool_name"]
+      raw_tool_input = attrs["tool_input"] || %{}
+
+      parsed_tool_input =
+        case ToolInputs.parse_tool_input(tool_name, raw_tool_input) do
+          {:ok, input} -> input
+          _ -> raw_tool_input
+        end
+
+      %__MODULE__{
+        session_id: attrs["session_id"],
+        transcript_path: attrs["transcript_path"],
+        cwd: attrs["cwd"],
+        hook_event_name: attrs["hook_event_name"] || "PostToolUse",
+        tool_name: tool_name,
+        tool_input: parsed_tool_input,
+        tool_response: attrs["tool_response"] || %{}
+      }
+    end
+
+    @doc """
+    Parses JSON string into PostToolUse Input struct.
+    """
+    def from_json(json) when is_binary(json) do
+      case Jason.decode(json) do
+        {:ok, data} -> {:ok, new(data)}
+        {:error, _} = error -> error
+      end
+    end
+  end
+
+  defmodule Output do
+    @moduledoc """
+    Output structure for PostToolUse hooks.
+
+    Can block tool execution and provide feedback to Claude.
+    """
+    defstruct continue: true,
+              stop_reason: nil,
+              suppress_output: false,
+              decision: nil,
+              reason: nil
+
+    @type decision :: :block | nil
+
+    @type t :: %__MODULE__{
+            continue: boolean(),
+            stop_reason: String.t() | nil,
+            suppress_output: boolean(),
+            decision: decision(),
+            reason: String.t() | nil
+          }
+
+    @doc """
+    Creates a PostToolUse Output that indicates success.
+    """
+    def success do
+      %__MODULE__{}
+    end
+
+    @doc """
+    Creates a PostToolUse Output that blocks with a reason.
+    """
+    def block(reason) do
+      %__MODULE__{
+        decision: :block,
+        reason: reason
+      }
+    end
+
+    @doc """
+    Creates a PostToolUse Output that allows continuation.
+    """
+    def allow do
+      %__MODULE__{}
+    end
+
+  end
+
+  defimpl Jason.Encoder, for: Output do
+    def encode(%Output{} = output, opts) do
+      output
+      |> Map.from_struct()
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+      |> JsonUtils.to_camel_case()
+      |> then(fn map ->
+        if map["decision"] do
+          Map.put(map, "decision", to_string(map["decision"]))
+        else
+          map
+        end
+      end)
+      |> Jason.Encode.map(opts)
+    end
+  end
+end

--- a/lib/claude/hooks/events/pre_compact.ex
+++ b/lib/claude/hooks/events/pre_compact.ex
@@ -1,0 +1,62 @@
+defmodule Claude.Hooks.Events.PreCompact do
+  @moduledoc """
+  PreCompact hook event structures.
+
+  Runs before Claude Code is about to run a compact operation.
+  """
+
+  defmodule Input do
+    @moduledoc """
+    Input data for PreCompact hook events.
+
+    Note: PreCompact events do not include a cwd field.
+    """
+    @derive Jason.Encoder
+    defstruct [:session_id, :transcript_path, :hook_event_name, :trigger, :custom_instructions]
+
+    @type trigger :: :manual | :auto
+
+    @type t :: %__MODULE__{
+            session_id: String.t(),
+            transcript_path: String.t(),
+            hook_event_name: String.t(),
+            trigger: trigger(),
+            custom_instructions: String.t()
+          }
+
+    @doc """
+    Creates a new PreCompact Input struct from a map.
+    """
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        session_id: attrs["session_id"],
+        transcript_path: attrs["transcript_path"],
+        hook_event_name: attrs["hook_event_name"] || "PreCompact",
+        trigger: parse_trigger(attrs["trigger"]),
+        custom_instructions: attrs["custom_instructions"] || ""
+      }
+    end
+
+    @doc """
+    Parses JSON string into PreCompact Input struct.
+    """
+    def from_json(json) when is_binary(json) do
+      case Jason.decode(json) do
+        {:ok, data} -> {:ok, new(data)}
+        {:error, _} = error -> error
+      end
+    end
+
+    defp parse_trigger("manual"), do: :manual
+    defp parse_trigger("auto"), do: :auto
+    defp parse_trigger(_), do: nil
+  end
+
+  # PreCompact hooks typically use SimpleOutput or basic exit codes
+  # No specific output structure needed
+  defmodule Output do
+    defdelegate success(stdout \\ nil), to: Claude.Hooks.Events.Common.SimpleOutput
+    defdelegate error(stderr, exit_code \\ 1), to: Claude.Hooks.Events.Common.SimpleOutput
+    defdelegate block(stderr), to: Claude.Hooks.Events.Common.SimpleOutput
+  end
+end

--- a/lib/claude/hooks/events/pre_tool_use.ex
+++ b/lib/claude/hooks/events/pre_tool_use.ex
@@ -1,0 +1,160 @@
+defmodule Claude.Hooks.Events.PreToolUse do
+  @moduledoc """
+  PreToolUse hook event structures.
+
+  Runs after Claude creates tool parameters and before processing the tool call.
+  """
+
+  alias Claude.Hooks.ToolInputs
+  alias Claude.Core.JsonUtils
+
+  defmodule Input do
+    @moduledoc """
+    Input data for PreToolUse hook events.
+    """
+    @derive Jason.Encoder
+    defstruct [:session_id, :transcript_path, :cwd, :hook_event_name, :tool_name, :tool_input]
+
+    @type t :: %__MODULE__{
+            session_id: String.t(),
+            transcript_path: String.t(),
+            cwd: String.t(),
+            hook_event_name: String.t(),
+            tool_name: String.t(),
+            tool_input: map() | struct()
+          }
+
+    @doc """
+    Creates a new PreToolUse Input struct from a map.
+
+    The tool_input field will be parsed into the appropriate tool-specific struct
+    based on the tool_name.
+    """
+    def new(attrs) when is_map(attrs) do
+      tool_name = attrs["tool_name"]
+      raw_tool_input = attrs["tool_input"] || %{}
+
+      parsed_tool_input =
+        case ToolInputs.parse_tool_input(tool_name, raw_tool_input) do
+          {:ok, input} -> input
+          _ -> raw_tool_input
+        end
+
+      %__MODULE__{
+        session_id: attrs["session_id"],
+        transcript_path: attrs["transcript_path"],
+        cwd: attrs["cwd"],
+        hook_event_name: attrs["hook_event_name"] || "PreToolUse",
+        tool_name: tool_name,
+        tool_input: parsed_tool_input
+      }
+    end
+
+    @doc """
+    Parses JSON string into PreToolUse Input struct.
+    """
+    def from_json(json) when is_binary(json) do
+      case Jason.decode(json) do
+        {:ok, data} -> {:ok, new(data)}
+        {:error, _} = error -> error
+      end
+    end
+  end
+
+  defmodule Output do
+    @moduledoc """
+    Output structure for PreToolUse hooks.
+
+    Supports permission decisions (allow/deny/ask) and backward compatibility
+    with deprecated decision/reason fields.
+    """
+    defstruct continue: true,
+              stop_reason: nil,
+              suppress_output: false,
+              hook_specific_output: nil,
+              decision: nil,
+              reason: nil
+
+    @type permission_decision :: :allow | :deny | :ask
+    @type deprecated_decision :: :approve | :block
+
+    @type hook_specific :: %{
+            hook_event_name: String.t(),
+            permission_decision: permission_decision(),
+            permission_decision_reason: String.t() | nil
+          }
+
+    @type t :: %__MODULE__{
+            continue: boolean(),
+            stop_reason: String.t() | nil,
+            suppress_output: boolean(),
+            hook_specific_output: hook_specific() | nil,
+            decision: deprecated_decision() | nil,
+            reason: String.t() | nil
+          }
+
+    @doc """
+    Creates a PreToolUse Output with an allow decision.
+    """
+    def allow(reason \\ nil) do
+      %__MODULE__{
+        hook_specific_output: %{
+          hook_event_name: "PreToolUse",
+          permission_decision: :allow,
+          permission_decision_reason: reason
+        }
+      }
+    end
+
+    @doc """
+    Creates a PreToolUse Output with a deny decision.
+    """
+    def deny(reason) do
+      %__MODULE__{
+        hook_specific_output: %{
+          hook_event_name: "PreToolUse",
+          permission_decision: :deny,
+          permission_decision_reason: reason
+        }
+      }
+    end
+
+    @doc """
+    Creates a PreToolUse Output with an ask decision.
+    """
+    def ask(reason \\ nil) do
+      %__MODULE__{
+        hook_specific_output: %{
+          hook_event_name: "PreToolUse",
+          permission_decision: :ask,
+          permission_decision_reason: reason
+        }
+      }
+    end
+
+  end
+
+  defimpl Jason.Encoder, for: Output do
+    def encode(%Output{} = output, opts) do
+      output
+      |> Map.from_struct()
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+      |> JsonUtils.to_camel_case()
+      |> then(fn map ->
+        if map["hookSpecificOutput"] do
+          original_hook_output = map["hookSpecificOutput"]
+          hook_output = original_hook_output
+          |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+          |> Map.new()
+          |> Map.put("permissionDecision", to_string(original_hook_output["permissionDecision"]))
+          
+          Map.put(map, "hookSpecificOutput", hook_output)
+        else
+          map
+        end
+      end)
+      |> Jason.Encode.map(opts)
+    end
+  end
+end

--- a/lib/claude/hooks/events/stop.ex
+++ b/lib/claude/hooks/events/stop.ex
@@ -1,0 +1,107 @@
+defmodule Claude.Hooks.Events.Stop do
+  @moduledoc """
+  Stop hook event structures.
+
+  Runs when the main Claude Code agent has finished responding.
+  """
+
+  alias Claude.Core.JsonUtils
+
+  defmodule Input do
+    @moduledoc """
+    Input data for Stop hook events.
+
+    Note: Stop events do not include a cwd field.
+    """
+    @derive Jason.Encoder
+    defstruct [:session_id, :transcript_path, :hook_event_name, :stop_hook_active]
+
+    @type t :: %__MODULE__{
+            session_id: String.t(),
+            transcript_path: String.t(),
+            hook_event_name: String.t(),
+            stop_hook_active: boolean()
+          }
+
+    @doc """
+    Creates a new Stop Input struct from a map.
+    """
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        session_id: attrs["session_id"],
+        transcript_path: attrs["transcript_path"],
+        hook_event_name: attrs["hook_event_name"] || "Stop",
+        stop_hook_active: attrs["stop_hook_active"] || false
+      }
+    end
+
+    @doc """
+    Parses JSON string into Stop Input struct.
+    """
+    def from_json(json) when is_binary(json) do
+      case Jason.decode(json) do
+        {:ok, data} -> {:ok, new(data)}
+        {:error, _} = error -> error
+      end
+    end
+  end
+
+  defmodule Output do
+    @moduledoc """
+    Output structure for Stop hooks.
+
+    Can prevent Claude from stopping and provide instructions to continue.
+    """
+    defstruct continue: true,
+              stop_reason: nil,
+              suppress_output: false,
+              decision: nil,
+              reason: nil
+
+    @type decision :: :block | nil
+
+    @type t :: %__MODULE__{
+            continue: boolean(),
+            stop_reason: String.t() | nil,
+            suppress_output: boolean(),
+            decision: decision(),
+            reason: String.t() | nil
+          }
+
+    @doc """
+    Creates a Stop Output that blocks Claude from stopping.
+    """
+    def block(reason) do
+      %__MODULE__{
+        decision: :block,
+        reason: reason
+      }
+    end
+
+    @doc """
+    Creates a Stop Output that allows Claude to stop.
+    """
+    def allow do
+      %__MODULE__{}
+    end
+
+  end
+
+  defimpl Jason.Encoder, for: Output do
+    def encode(%Output{} = output, opts) do
+      output
+      |> Map.from_struct()
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+      |> JsonUtils.to_camel_case()
+      |> then(fn map ->
+        if map["decision"] do
+          Map.put(map, "decision", to_string(map["decision"]))
+        else
+          map
+        end
+      end)
+      |> Jason.Encode.map(opts)
+    end
+  end
+end

--- a/lib/claude/hooks/events/user_prompt_submit.ex
+++ b/lib/claude/hooks/events/user_prompt_submit.ex
@@ -1,0 +1,138 @@
+defmodule Claude.Hooks.Events.UserPromptSubmit do
+  @moduledoc """
+  UserPromptSubmit hook event structures.
+
+  Runs when the user submits a prompt, before Claude processes it.
+  """
+
+  alias Claude.Core.JsonUtils
+
+  defmodule Input do
+    @moduledoc """
+    Input data for UserPromptSubmit hook events.
+    """
+    @derive Jason.Encoder
+    defstruct [:session_id, :transcript_path, :cwd, :hook_event_name, :prompt]
+
+    @type t :: %__MODULE__{
+            session_id: String.t(),
+            transcript_path: String.t(),
+            cwd: String.t(),
+            hook_event_name: String.t(),
+            prompt: String.t()
+          }
+
+    @doc """
+    Creates a new UserPromptSubmit Input struct from a map.
+    """
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        session_id: attrs["session_id"],
+        transcript_path: attrs["transcript_path"],
+        cwd: attrs["cwd"],
+        hook_event_name: attrs["hook_event_name"] || "UserPromptSubmit",
+        prompt: attrs["prompt"]
+      }
+    end
+
+    @doc """
+    Parses JSON string into UserPromptSubmit Input struct.
+    """
+    def from_json(json) when is_binary(json) do
+      case Jason.decode(json) do
+        {:ok, data} -> {:ok, new(data)}
+        {:error, _} = error -> error
+      end
+    end
+  end
+
+  defmodule Output do
+    @moduledoc """
+    Output structure for UserPromptSubmit hooks.
+
+    Can block prompts and add additional context.
+    """
+    defstruct continue: true,
+              stop_reason: nil,
+              suppress_output: false,
+              decision: nil,
+              reason: nil,
+              hook_specific_output: nil
+
+    @type decision :: :block | nil
+
+    @type hook_specific :: %{
+            hook_event_name: String.t(),
+            additional_context: String.t() | nil
+          }
+
+    @type t :: %__MODULE__{
+            continue: boolean(),
+            stop_reason: String.t() | nil,
+            suppress_output: boolean(),
+            decision: decision(),
+            reason: String.t() | nil,
+            hook_specific_output: hook_specific() | nil
+          }
+
+    @doc """
+    Creates a UserPromptSubmit Output that allows the prompt.
+    """
+    def allow do
+      %__MODULE__{}
+    end
+
+    @doc """
+    Creates a UserPromptSubmit Output that allows with additional context.
+    """
+    def allow_with_context(context) do
+      %__MODULE__{
+        hook_specific_output: %{
+          hook_event_name: "UserPromptSubmit",
+          additional_context: context
+        }
+      }
+    end
+
+    @doc """
+    Creates a UserPromptSubmit Output that blocks the prompt.
+    """
+    def block(reason) do
+      %__MODULE__{
+        decision: :block,
+        reason: reason
+      }
+    end
+
+    @doc """
+    Creates a UserPromptSubmit Output that adds context.
+    """
+    def add_context(context) do
+      %__MODULE__{
+        hook_specific_output: %{
+          hook_event_name: "UserPromptSubmit",
+          additional_context: context
+        }
+      }
+    end
+
+  end
+
+  defimpl Jason.Encoder, for: Output do
+    def encode(%Output{} = output, opts) do
+      output
+      |> Map.from_struct()
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+      |> JsonUtils.to_camel_case()
+      |> then(fn map ->
+        if map["decision"] do
+          Map.put(map, "decision", to_string(map["decision"]))
+        else
+          map
+        end
+      end)
+      |> Jason.Encode.map(opts)
+    end
+  end
+end

--- a/lib/claude/hooks/tool_inputs.ex
+++ b/lib/claude/hooks/tool_inputs.ex
@@ -1,0 +1,429 @@
+defmodule Claude.Hooks.ToolInputs do
+  @moduledoc """
+  Structs for specific tool input types used by Claude Code.
+
+  Each tool has its own input structure that matches the parameters
+  Claude Code sends to hooks in the tool_input field.
+  """
+
+  defmodule Task do
+    @moduledoc """
+    Input for the Task tool (sub-agent).
+    """
+    @derive Jason.Encoder
+    defstruct [:description, :prompt]
+
+    @type t :: %__MODULE__{
+            description: String.t(),
+            prompt: String.t()
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        description: attrs["description"],
+        prompt: attrs["prompt"]
+      }
+    end
+  end
+
+  defmodule Bash do
+    @moduledoc """
+    Input for the Bash tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:command, :description, :timeout]
+
+    @type t :: %__MODULE__{
+            command: String.t(),
+            description: String.t() | nil,
+            timeout: integer() | nil
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        command: attrs["command"],
+        description: attrs["description"],
+        timeout: attrs["timeout"]
+      }
+    end
+  end
+
+  defmodule Edit do
+    @moduledoc """
+    Input for the Edit tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:file_path, :old_string, :new_string, :replace_all]
+
+    @type t :: %__MODULE__{
+            file_path: String.t(),
+            old_string: String.t(),
+            new_string: String.t(),
+            replace_all: boolean() | nil
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        file_path: attrs["file_path"],
+        old_string: attrs["old_string"],
+        new_string: attrs["new_string"],
+        replace_all: attrs["replace_all"] || false
+      }
+    end
+  end
+
+  defmodule MultiEdit do
+    @moduledoc """
+    Input for the MultiEdit tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:file_path, :edits]
+
+    @type edit :: %{
+            old_string: String.t(),
+            new_string: String.t(),
+            replace_all: boolean() | nil
+          }
+
+    @type t :: %__MODULE__{
+            file_path: String.t(),
+            edits: [edit()]
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        file_path: attrs["file_path"],
+        edits: parse_edits(attrs["edits"] || [])
+      }
+    end
+
+    defp parse_edits(edits) when is_list(edits) do
+      Enum.map(edits, fn edit ->
+        %{
+          old_string: edit["old_string"],
+          new_string: edit["new_string"],
+          replace_all: edit["replace_all"] || false
+        }
+      end)
+    end
+  end
+
+  defmodule Write do
+    @moduledoc """
+    Input for the Write tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:file_path, :content]
+
+    @type t :: %__MODULE__{
+            file_path: String.t(),
+            content: String.t()
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        file_path: attrs["file_path"],
+        content: attrs["content"]
+      }
+    end
+  end
+
+  defmodule Read do
+    @moduledoc """
+    Input for the Read tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:file_path, :limit, :offset]
+
+    @type t :: %__MODULE__{
+            file_path: String.t(),
+            limit: integer() | nil,
+            offset: integer() | nil
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        file_path: attrs["file_path"],
+        limit: attrs["limit"],
+        offset: attrs["offset"]
+      }
+    end
+  end
+
+  defmodule Glob do
+    @moduledoc """
+    Input for the Glob tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:path, :pattern]
+
+    @type t :: %__MODULE__{
+            path: String.t() | nil,
+            pattern: String.t()
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        path: attrs["path"],
+        pattern: attrs["pattern"]
+      }
+    end
+  end
+
+  defmodule Grep do
+    @moduledoc """
+    Input for the Grep tool.
+    """
+    @derive Jason.Encoder
+    defstruct [
+      :pattern,
+      :path,
+      :type,
+      :glob,
+      :output_mode,
+      :head_limit,
+      :multiline,
+      "-A": nil,
+      "-B": nil,
+      "-C": nil,
+      "-i": nil,
+      "-n": nil
+    ]
+
+    @type output_mode :: :content | :files_with_matches | :count
+
+    @type t :: %__MODULE__{
+            pattern: String.t(),
+            path: String.t() | nil,
+            type: String.t() | nil,
+            glob: String.t() | nil,
+            output_mode: output_mode() | nil,
+            head_limit: integer() | nil,
+            multiline: boolean() | nil,
+            "-A": integer() | nil,
+            "-B": integer() | nil,
+            "-C": integer() | nil,
+            "-i": boolean() | nil,
+            "-n": boolean() | nil
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        pattern: attrs["pattern"],
+        path: attrs["path"],
+        type: attrs["type"],
+        glob: attrs["glob"],
+        output_mode: parse_output_mode(attrs["output_mode"]),
+        head_limit: attrs["head_limit"],
+        multiline: attrs["multiline"],
+        "-A": attrs["-A"],
+        "-B": attrs["-B"],
+        "-C": attrs["-C"],
+        "-i": attrs["-i"],
+        "-n": attrs["-n"]
+      }
+    end
+
+    defp parse_output_mode("content"), do: :content
+    defp parse_output_mode("files_with_matches"), do: :files_with_matches
+    defp parse_output_mode("count"), do: :count
+    defp parse_output_mode(_), do: :files_with_matches
+  end
+
+  defmodule LS do
+    @moduledoc """
+    Input for the LS tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:path, :ignore]
+
+    @type t :: %__MODULE__{
+            path: String.t(),
+            ignore: [String.t()] | nil
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        path: attrs["path"],
+        ignore: attrs["ignore"]
+      }
+    end
+  end
+
+  defmodule NotebookRead do
+    @moduledoc """
+    Input for the NotebookRead tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:notebook_path, :cell_id]
+
+    @type t :: %__MODULE__{
+            notebook_path: String.t(),
+            cell_id: String.t() | nil
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        notebook_path: attrs["notebook_path"],
+        cell_id: attrs["cell_id"]
+      }
+    end
+  end
+
+  defmodule NotebookEdit do
+    @moduledoc """
+    Input for the NotebookEdit tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:notebook_path, :new_source, :cell_id, :cell_type, :edit_mode]
+
+    @type cell_type :: :code | :markdown
+    @type edit_mode :: :replace | :insert | :delete
+
+    @type t :: %__MODULE__{
+            notebook_path: String.t(),
+            new_source: String.t(),
+            cell_id: String.t() | nil,
+            cell_type: cell_type() | nil,
+            edit_mode: edit_mode() | nil
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        notebook_path: attrs["notebook_path"],
+        new_source: attrs["new_source"],
+        cell_id: attrs["cell_id"],
+        cell_type: parse_cell_type(attrs["cell_type"]),
+        edit_mode: parse_edit_mode(attrs["edit_mode"])
+      }
+    end
+
+    defp parse_cell_type("code"), do: :code
+    defp parse_cell_type("markdown"), do: :markdown
+    defp parse_cell_type(_), do: nil
+
+    defp parse_edit_mode("replace"), do: :replace
+    defp parse_edit_mode("insert"), do: :insert
+    defp parse_edit_mode("delete"), do: :delete
+    defp parse_edit_mode(_), do: :replace
+  end
+
+  defmodule WebFetch do
+    @moduledoc """
+    Input for the WebFetch tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:url, :prompt]
+
+    @type t :: %__MODULE__{
+            url: String.t(),
+            prompt: String.t()
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        url: attrs["url"],
+        prompt: attrs["prompt"]
+      }
+    end
+  end
+
+  defmodule WebSearch do
+    @moduledoc """
+    Input for the WebSearch tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:query, :allowed_domains, :blocked_domains]
+
+    @type t :: %__MODULE__{
+            query: String.t(),
+            allowed_domains: [String.t()] | nil,
+            blocked_domains: [String.t()] | nil
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        query: attrs["query"],
+        allowed_domains: attrs["allowed_domains"],
+        blocked_domains: attrs["blocked_domains"]
+      }
+    end
+  end
+
+  defmodule TodoWrite do
+    @moduledoc """
+    Input for the TodoWrite tool.
+    """
+    @derive Jason.Encoder
+    defstruct [:todos]
+
+    @type todo :: %{
+            content: String.t(),
+            status: :pending | :in_progress | :completed,
+            priority: :high | :medium | :low,
+            id: String.t()
+          }
+
+    @type t :: %__MODULE__{
+            todos: [todo()]
+          }
+
+    def new(attrs) when is_map(attrs) do
+      %__MODULE__{
+        todos: parse_todos(attrs["todos"] || [])
+      }
+    end
+
+    defp parse_todos(todos) when is_list(todos) do
+      Enum.map(todos, fn todo ->
+        %{
+          content: todo["content"],
+          status: parse_status(todo["status"]),
+          priority: parse_priority(todo["priority"]),
+          id: todo["id"]
+        }
+      end)
+    end
+
+    defp parse_status("pending"), do: :pending
+    defp parse_status("in_progress"), do: :in_progress
+    defp parse_status("completed"), do: :completed
+    defp parse_status(_), do: :pending
+
+    defp parse_priority("high"), do: :high
+    defp parse_priority("medium"), do: :medium
+    defp parse_priority("low"), do: :low
+    defp parse_priority(_), do: :medium
+  end
+
+  @doc """
+  Parses a tool_input map into the appropriate tool input struct based on tool_name.
+
+  ## Examples
+
+      iex> tool_input = %{"file_path" => "/test.ex", "content" => "defmodule Test do\\nend"}
+      iex> {:ok, input} = Claude.Hooks.ToolInputs.parse_tool_input("Write", tool_input)
+      iex> match?(%Claude.Hooks.ToolInputs.Write{}, input)
+      true
+  """
+  def parse_tool_input(tool_name, tool_input) when is_binary(tool_name) and is_map(tool_input) do
+    case tool_name do
+      "Task" -> {:ok, Task.new(tool_input)}
+      "Bash" -> {:ok, Bash.new(tool_input)}
+      "Edit" -> {:ok, Edit.new(tool_input)}
+      "MultiEdit" -> {:ok, MultiEdit.new(tool_input)}
+      "Write" -> {:ok, Write.new(tool_input)}
+      "Read" -> {:ok, Read.new(tool_input)}
+      "Glob" -> {:ok, Glob.new(tool_input)}
+      "Grep" -> {:ok, Grep.new(tool_input)}
+      "LS" -> {:ok, LS.new(tool_input)}
+      "NotebookRead" -> {:ok, NotebookRead.new(tool_input)}
+      "NotebookEdit" -> {:ok, NotebookEdit.new(tool_input)}
+      "WebFetch" -> {:ok, WebFetch.new(tool_input)}
+      "WebSearch" -> {:ok, WebSearch.new(tool_input)}
+      "TodoWrite" -> {:ok, TodoWrite.new(tool_input)}
+      # Return raw map for unknown tools
+      _ -> {:ok, tool_input}
+    end
+  end
+end

--- a/test/claude/hooks/events/common_test.exs
+++ b/test/claude/hooks/events/common_test.exs
@@ -1,0 +1,206 @@
+defmodule Claude.Hooks.Events.CommonTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events.Common
+  alias Claude.Hooks.Events
+
+  describe "parse_hook_input/1" do
+    test "routes to PreToolUse for PreToolUse event" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "cwd": "/project",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_input": {"file_path": "/test.ex", "content": "test"}
+      })
+
+      {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.PreToolUse.Input{} = event
+      assert event.tool_name == "Write"
+    end
+
+    test "routes to PostToolUse for PostToolUse event" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "cwd": "/project",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Write",
+        "tool_input": {"file_path": "/test.ex", "content": "test"},
+        "tool_response": {"success": true}
+      })
+
+      {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.PostToolUse.Input{} = event
+      assert event.tool_response["success"] == true
+    end
+
+    test "routes to Notification for Notification event" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "cwd": "/project",
+        "hook_event_name": "Notification",
+        "message": "Test notification"
+      })
+
+      {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.Notification.Input{} = event
+      assert event.message == "Test notification"
+    end
+
+    test "routes to UserPromptSubmit for UserPromptSubmit event" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "cwd": "/project",
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Test prompt"
+      })
+
+      {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.UserPromptSubmit.Input{} = event
+      assert event.prompt == "Test prompt"
+    end
+
+    test "routes to Stop for Stop event" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "hook_event_name": "Stop",
+        "stop_hook_active": true
+      })
+
+      {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.Stop.Input{} = event
+      assert event.stop_hook_active == true
+    end
+
+    test "routes to SubagentStop for SubagentStop event" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "hook_event_name": "SubagentStop",
+        "stop_hook_active": false
+      })
+
+      {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.SubagentStop.Input{} = event
+      assert event.stop_hook_active == false
+    end
+
+    test "routes to PreCompact for PreCompact event" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "hook_event_name": "PreCompact",
+        "trigger": "manual",
+        "custom_instructions": "Test"
+      })
+
+      {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.PreCompact.Input{} = event
+      assert event.trigger == :manual
+    end
+
+    test "returns error for unknown event type" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "hook_event_name": "UnknownEvent"
+      })
+
+      assert {:error, "Unknown hook event name: \"UnknownEvent\""} = Common.parse_hook_input(json)
+    end
+
+    test "returns error for invalid JSON" do
+      assert {:error, %Jason.DecodeError{}} = Common.parse_hook_input("not json")
+    end
+
+    test "returns error for non-string input" do
+      assert {:error, _} = Common.parse_hook_input(123)
+      assert {:error, _} = Common.parse_hook_input(nil)
+      assert {:error, _} = Common.parse_hook_input(%{})
+    end
+  end
+
+  describe "SimpleOutput" do
+    test "success/0 creates exit code 0 output" do
+      output = Common.SimpleOutput.success()
+
+      assert output.exit_code == 0
+      assert output.stdout == nil
+      assert output.stderr == nil
+    end
+
+    test "success/1 creates exit code 0 output with stdout" do
+      output = Common.SimpleOutput.success("Operation completed")
+
+      assert output.exit_code == 0
+      assert output.stdout == "Operation completed"
+      assert output.stderr == nil
+    end
+
+    test "error/1 creates exit code 1 output with stderr" do
+      output = Common.SimpleOutput.error("Something went wrong")
+
+      assert output.exit_code == 1
+      assert output.stdout == nil
+      assert output.stderr == "Something went wrong"
+    end
+
+    test "block/1 creates exit code 2 output with stderr" do
+      output = Common.SimpleOutput.block("Operation blocked")
+
+      assert output.exit_code == 2
+      assert output.stdout == nil
+      assert output.stderr == "Operation blocked"
+    end
+
+    test "output can be encoded to JSON string" do
+      output = Common.SimpleOutput.success("Done")
+      json = Jason.encode!(output)
+
+      assert is_binary(json)
+      decoded = Jason.decode!(json)
+
+      assert decoded["exitCode"] == 0
+      assert decoded["stdout"] == "Done"
+    end
+
+    test "write_and_exit/1 writes JSON to stdout (mocked)" do
+      output = Common.SimpleOutput.success("Test")
+      
+      # Since write_and_exit calls System.halt, we can't test it directly
+      # but we can verify the JSON structure it would output
+      json = Jason.encode!(output)
+      assert json =~ ~s("exitCode":0)
+      assert json =~ ~s("stdout":"Test")
+    end
+
+    test "Jason.Encoder implementation converts to camelCase" do
+      output = %Common.SimpleOutput{
+        exit_code: 1,
+        stdout: "output",
+        stderr: "error"
+      }
+
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded["exitCode"] == 1
+      assert decoded["stdout"] == "output"
+      assert decoded["stderr"] == "error"
+    end
+
+    test "Jason.Encoder filters nil values" do
+      output = Common.SimpleOutput.success()
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded == %{"exitCode" => 0}
+      refute Map.has_key?(decoded, "stdout")
+      refute Map.has_key?(decoded, "stderr")
+    end
+  end
+end

--- a/test/claude/hooks/events/notification_test.exs
+++ b/test/claude/hooks/events/notification_test.exs
@@ -1,0 +1,133 @@
+defmodule Claude.Hooks.Events.NotificationTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events.Notification
+
+  describe "Input" do
+    test "new/1 creates struct from map" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "hook_event_name" => "Notification",
+        "message" => "Claude needs your permission to use Bash"
+      }
+
+      input = Notification.Input.new(attrs)
+
+      assert input.session_id == "test-123"
+      assert input.transcript_path == "/path/to/transcript.jsonl"
+      assert input.cwd == "/project"
+      assert input.hook_event_name == "Notification"
+      assert input.message == "Claude needs your permission to use Bash"
+    end
+
+    test "new/1 defaults hook_event_name if not provided" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "message" => "Test notification"
+      }
+
+      input = Notification.Input.new(attrs)
+      assert input.hook_event_name == "Notification"
+    end
+
+    test "from_json/1 parses valid JSON" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "cwd": "/project",
+        "hook_event_name": "Notification",
+        "message": "Claude is waiting for your input"
+      })
+
+      {:ok, input} = Notification.Input.from_json(json)
+
+      assert input.session_id == "test-123"
+      assert input.message == "Claude is waiting for your input"
+    end
+
+    test "from_json/1 handles invalid JSON" do
+      assert {:error, _} = Notification.Input.from_json("invalid json")
+    end
+
+    test "Jason.Encoder implementation encodes Input struct" do
+      input = %Notification.Input{
+        session_id: "test-123",
+        transcript_path: "/path/to/transcript.jsonl",
+        cwd: "/project",
+        hook_event_name: "Notification",
+        message: "Test message"
+      }
+
+      json = Jason.encode!(input)
+      decoded = Jason.decode!(json)
+
+      assert decoded["session_id"] == "test-123"
+      assert decoded["message"] == "Test message"
+      assert decoded["cwd"] == "/project"
+    end
+  end
+
+  describe "Output" do
+    test "Output is aliased to Common.SimpleOutput" do
+      # Notification.Output should be Common.SimpleOutput
+      output = Notification.Output.success("Logged")
+      assert %Claude.Hooks.Events.Common.SimpleOutput{} = output
+    end
+
+    test "success/0 creates success output" do
+      output = Notification.Output.success()
+
+      assert output.exit_code == 0
+      assert output.stdout == nil
+      assert output.stderr == nil
+    end
+
+    test "success/1 creates success output with message" do
+      output = Notification.Output.success("Notification received")
+
+      assert output.exit_code == 0
+      assert output.stdout == "Notification received"
+      assert output.stderr == nil
+    end
+
+    test "error/1 creates error output" do
+      output = Notification.Output.error("Failed to process")
+
+      assert output.exit_code == 1
+      assert output.stdout == nil
+      assert output.stderr == "Failed to process"
+    end
+
+    test "block/1 creates blocking output" do
+      output = Notification.Output.block("Cannot proceed")
+
+      assert output.exit_code == 2
+      assert output.stdout == nil
+      assert output.stderr == "Cannot proceed"
+    end
+
+    test "output can be encoded to JSON string" do
+      output = Notification.Output.success("Logged notification")
+      json = Jason.encode!(output)
+
+      assert is_binary(json)
+      decoded = Jason.decode!(json)
+
+      assert decoded["exitCode"] == 0
+      assert decoded["stdout"] == "Logged notification"
+    end
+
+    test "Jason.Encoder filters nil values" do
+      output = Notification.Output.success()
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded == %{"exitCode" => 0}
+      refute Map.has_key?(decoded, "stdout")
+      refute Map.has_key?(decoded, "stderr")
+    end
+  end
+end

--- a/test/claude/hooks/events/post_tool_use_test.exs
+++ b/test/claude/hooks/events/post_tool_use_test.exs
@@ -1,0 +1,162 @@
+defmodule Claude.Hooks.Events.PostToolUseTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events.PostToolUse
+
+  describe "Input" do
+    test "new/1 creates struct from map with tool response" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "hook_event_name" => "PostToolUse",
+        "tool_name" => "Write",
+        "tool_input" => %{
+          "file_path" => "/test.ex",
+          "content" => "defmodule Test do\nend"
+        },
+        "tool_response" => %{
+          "filePath" => "/test.ex",
+          "success" => true
+        }
+      }
+
+      input = PostToolUse.Input.new(attrs)
+
+      assert input.session_id == "test-123"
+      assert input.transcript_path == "/path/to/transcript.jsonl"
+      assert input.cwd == "/project"
+      assert input.hook_event_name == "PostToolUse"
+      assert input.tool_name == "Write"
+      assert %Claude.Hooks.ToolInputs.Write{} = input.tool_input
+      assert input.tool_input.file_path == "/test.ex"
+      assert input.tool_response == %{"filePath" => "/test.ex", "success" => true}
+    end
+
+    test "new/1 defaults hook_event_name if not provided" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "tool_name" => "Bash",
+        "tool_input" => %{"command" => "ls"},
+        "tool_response" => %{"exitCode" => 0}
+      }
+
+      input = PostToolUse.Input.new(attrs)
+      assert input.hook_event_name == "PostToolUse"
+    end
+
+    test "from_json/1 parses valid JSON" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "cwd": "/project",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Edit",
+        "tool_input": {
+          "file_path": "/test.ex",
+          "old_string": "old",
+          "new_string": "new"
+        },
+        "tool_response": {
+          "success": true,
+          "linesModified": 5
+        }
+      })
+
+      {:ok, input} = PostToolUse.Input.from_json(json)
+
+      assert input.session_id == "test-123"
+      assert input.tool_name == "Edit"
+      assert %Claude.Hooks.ToolInputs.Edit{} = input.tool_input
+      assert input.tool_response["success"] == true
+      assert input.tool_response["linesModified"] == 5
+    end
+
+    test "from_json/1 handles invalid JSON" do
+      assert {:error, _} = PostToolUse.Input.from_json("invalid json")
+    end
+
+    test "Jason.Encoder implementation encodes Input struct" do
+      input = %PostToolUse.Input{
+        session_id: "test-123",
+        transcript_path: "/path/to/transcript.jsonl",
+        cwd: "/project",
+        hook_event_name: "PostToolUse",
+        tool_name: "Write",
+        tool_input: %Claude.Hooks.ToolInputs.Write{
+          file_path: "/test.ex",
+          content: "content"
+        },
+        tool_response: %{"success" => true}
+      }
+
+      json = Jason.encode!(input)
+      decoded = Jason.decode!(json)
+
+      assert decoded["session_id"] == "test-123"
+      assert decoded["tool_name"] == "Write"
+      assert decoded["tool_response"]["success"] == true
+    end
+  end
+
+  describe "Output" do
+    test "success/0 creates success output" do
+      output = PostToolUse.Output.success()
+
+      assert output.continue == true
+      assert output.decision == nil
+      assert output.reason == nil
+    end
+
+    test "block/1 creates block decision output" do
+      output = PostToolUse.Output.block("Tests failed after edit")
+
+      assert output.continue == true
+      assert output.decision == :block
+      assert output.reason == "Tests failed after edit"
+    end
+
+    test "output can be encoded to JSON string" do
+      output = PostToolUse.Output.block("Compilation error")
+      json = Jason.encode!(output)
+
+      assert is_binary(json)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == true
+      assert decoded["decision"] == "block"
+      assert decoded["reason"] == "Compilation error"
+    end
+
+    test "Jason.Encoder implementation converts snake_case to camelCase" do
+      output = %PostToolUse.Output{
+        continue: false,
+        stop_reason: "Critical error",
+        suppress_output: true,
+        decision: :block,
+        reason: "Failed"
+      }
+
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == false
+      assert decoded["stopReason"] == "Critical error"
+      assert decoded["suppressOutput"] == true
+      assert decoded["decision"] == "block"
+      assert decoded["reason"] == "Failed"
+    end
+
+    test "Jason.Encoder filters nil values" do
+      output = PostToolUse.Output.success()
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded == %{"continue" => true, "suppressOutput" => false}
+      refute Map.has_key?(decoded, "stopReason")
+      refute Map.has_key?(decoded, "decision")
+      refute Map.has_key?(decoded, "reason")
+    end
+  end
+end

--- a/test/claude/hooks/events/pre_compact_test.exs
+++ b/test/claude/hooks/events/pre_compact_test.exs
@@ -1,0 +1,133 @@
+defmodule Claude.Hooks.Events.PreCompactTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events.PreCompact
+
+  describe "Input" do
+    test "new/1 creates struct from map with manual trigger" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "PreCompact",
+        "trigger" => "manual",
+        "custom_instructions" => "Keep all test files"
+      }
+
+      input = PreCompact.Input.new(attrs)
+
+      assert input.session_id == "test-123"
+      assert input.transcript_path == "/path/to/transcript.jsonl"
+      assert input.hook_event_name == "PreCompact"
+      assert input.trigger == :manual
+      assert input.custom_instructions == "Keep all test files"
+    end
+
+    test "new/1 creates struct from map with auto trigger" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "PreCompact",
+        "trigger" => "auto",
+        "custom_instructions" => ""
+      }
+
+      input = PreCompact.Input.new(attrs)
+
+      assert input.trigger == :auto
+      assert input.custom_instructions == ""
+    end
+
+    test "new/1 defaults hook_event_name if not provided" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "trigger" => "manual",
+        "custom_instructions" => "Test"
+      }
+
+      input = PreCompact.Input.new(attrs)
+      assert input.hook_event_name == "PreCompact"
+    end
+
+    test "from_json/1 parses valid JSON" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "hook_event_name": "PreCompact",
+        "trigger": "manual",
+        "custom_instructions": "Preserve important context"
+      })
+
+      {:ok, input} = PreCompact.Input.from_json(json)
+
+      assert input.session_id == "test-123"
+      assert input.trigger == :manual
+      assert input.custom_instructions == "Preserve important context"
+    end
+
+    test "from_json/1 handles invalid JSON" do
+      assert {:error, _} = PreCompact.Input.from_json("invalid json")
+    end
+
+    test "Jason.Encoder implementation encodes Input struct" do
+      input = %PreCompact.Input{
+        session_id: "test-123",
+        transcript_path: "/path/to/transcript.jsonl",
+        hook_event_name: "PreCompact",
+        trigger: "auto",
+        custom_instructions: ""
+      }
+
+      json = Jason.encode!(input)
+      decoded = Jason.decode!(json)
+
+      assert decoded["session_id"] == "test-123"
+      assert decoded["trigger"] == "auto"
+      assert decoded["custom_instructions"] == ""
+      # Note: PreCompact events don't have cwd field
+      refute Map.has_key?(decoded, "cwd")
+    end
+  end
+
+  describe "Output" do
+    test "Output is aliased to Common.SimpleOutput" do
+      # PreCompact.Output should be Common.SimpleOutput
+      output = PreCompact.Output.success("Compaction allowed")
+      assert %Claude.Hooks.Events.Common.SimpleOutput{} = output
+    end
+
+    test "success/0 creates success output" do
+      output = PreCompact.Output.success()
+
+      assert output.exit_code == 0
+      assert output.stdout == nil
+      assert output.stderr == nil
+    end
+
+    test "success/1 creates success output with message" do
+      output = PreCompact.Output.success("Ready to compact")
+
+      assert output.exit_code == 0
+      assert output.stdout == "Ready to compact"
+      assert output.stderr == nil
+    end
+
+    test "error/1 creates error output" do
+      output = PreCompact.Output.error("Cannot compact now")
+
+      assert output.exit_code == 1
+      assert output.stdout == nil
+      assert output.stderr == "Cannot compact now"
+    end
+
+    test "output can be encoded to JSON string" do
+      output = PreCompact.Output.success("Compaction approved")
+      json = Jason.encode!(output)
+
+      assert is_binary(json)
+      decoded = Jason.decode!(json)
+
+      assert decoded["exitCode"] == 0
+      assert decoded["stdout"] == "Compaction approved"
+    end
+  end
+end

--- a/test/claude/hooks/events/pre_tool_use_test.exs
+++ b/test/claude/hooks/events/pre_tool_use_test.exs
@@ -1,0 +1,209 @@
+defmodule Claude.Hooks.Events.PreToolUseTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events.PreToolUse
+
+  describe "Input" do
+    test "new/1 creates struct from map" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "hook_event_name" => "PreToolUse",
+        "tool_name" => "Write",
+        "tool_input" => %{
+          "file_path" => "/test.ex",
+          "content" => "defmodule Test do\nend"
+        }
+      }
+
+      input = PreToolUse.Input.new(attrs)
+
+      assert input.session_id == "test-123"
+      assert input.transcript_path == "/path/to/transcript.jsonl"
+      assert input.cwd == "/project"
+      assert input.hook_event_name == "PreToolUse"
+      assert input.tool_name == "Write"
+      assert %Claude.Hooks.ToolInputs.Write{} = input.tool_input
+      assert input.tool_input.file_path == "/test.ex"
+      assert input.tool_input.content == "defmodule Test do\nend"
+    end
+
+    test "new/1 defaults hook_event_name if not provided" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "tool_name" => "Bash",
+        "tool_input" => %{"command" => "ls"}
+      }
+
+      input = PreToolUse.Input.new(attrs)
+      assert input.hook_event_name == "PreToolUse"
+    end
+
+    test "new/1 handles unknown tools by keeping raw map" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "tool_name" => "UnknownTool",
+        "tool_input" => %{"custom" => "data"}
+      }
+
+      input = PreToolUse.Input.new(attrs)
+      assert input.tool_input == %{"custom" => "data"}
+    end
+
+    test "from_json/1 parses valid JSON" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "cwd": "/project",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "tool_input": {
+          "file_path": "/test.ex",
+          "old_string": "old",
+          "new_string": "new"
+        }
+      })
+
+      {:ok, input} = PreToolUse.Input.from_json(json)
+
+      assert input.session_id == "test-123"
+      assert input.tool_name == "Edit"
+      assert %Claude.Hooks.ToolInputs.Edit{} = input.tool_input
+      assert input.tool_input.file_path == "/test.ex"
+      assert input.tool_input.old_string == "old"
+      assert input.tool_input.new_string == "new"
+    end
+
+    test "from_json/1 handles invalid JSON" do
+      assert {:error, _} = PreToolUse.Input.from_json("invalid json")
+    end
+
+    test "Jason.Encoder implementation encodes Input struct" do
+      input = %PreToolUse.Input{
+        session_id: "test-123",
+        transcript_path: "/path/to/transcript.jsonl",
+        cwd: "/project",
+        hook_event_name: "PreToolUse",
+        tool_name: "Write",
+        tool_input: %Claude.Hooks.ToolInputs.Write{
+          file_path: "/test.ex",
+          content: "content"
+        }
+      }
+
+      json = Jason.encode!(input)
+      decoded = Jason.decode!(json)
+
+      assert decoded["session_id"] == "test-123"
+      assert decoded["tool_name"] == "Write"
+      assert decoded["tool_input"]["file_path"] == "/test.ex"
+      assert decoded["tool_input"]["content"] == "content"
+    end
+  end
+
+  describe "Output" do
+    test "allow/0 creates allow decision output" do
+      output = PreToolUse.Output.allow()
+
+      assert output.continue == true
+      assert output.hook_specific_output.permission_decision == :allow
+      assert output.hook_specific_output.permission_decision_reason == nil
+      assert output.hook_specific_output.hook_event_name == "PreToolUse"
+    end
+
+    test "allow/1 creates allow decision with reason" do
+      output = PreToolUse.Output.allow("Auto-approved for read operations")
+
+      assert output.hook_specific_output.permission_decision == :allow
+      assert output.hook_specific_output.permission_decision_reason == "Auto-approved for read operations"
+    end
+
+    test "deny/1 creates deny decision output" do
+      output = PreToolUse.Output.deny("Dangerous operation detected")
+
+      assert output.continue == true
+      assert output.hook_specific_output.permission_decision == :deny
+      assert output.hook_specific_output.permission_decision_reason == "Dangerous operation detected"
+    end
+
+    test "ask/0 creates ask decision output" do
+      output = PreToolUse.Output.ask()
+
+      assert output.continue == true
+      assert output.hook_specific_output.permission_decision == :ask
+      assert output.hook_specific_output.permission_decision_reason == nil
+    end
+
+    test "ask/1 creates ask decision with reason" do
+      output = PreToolUse.Output.ask("Manual review required")
+
+      assert output.hook_specific_output.permission_decision == :ask
+      assert output.hook_specific_output.permission_decision_reason == "Manual review required"
+    end
+
+    test "output can be encoded to JSON string" do
+      output = PreToolUse.Output.allow("Test reason")
+      json = Jason.encode!(output)
+
+      assert is_binary(json)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == true
+      assert decoded["hookSpecificOutput"]["permissionDecision"] == "allow"
+      assert decoded["hookSpecificOutput"]["permissionDecisionReason"] == "Test reason"
+      assert decoded["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    end
+
+    test "Jason.Encoder implementation converts snake_case to camelCase" do
+      output = %PreToolUse.Output{
+        continue: false,
+        stop_reason: "Test stop",
+        suppress_output: true,
+        hook_specific_output: %{
+          hook_event_name: "PreToolUse",
+          permission_decision: :deny,
+          permission_decision_reason: "Not allowed"
+        }
+      }
+
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == false
+      assert decoded["stopReason"] == "Test stop"
+      assert decoded["suppressOutput"] == true
+      assert decoded["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+      assert decoded["hookSpecificOutput"]["permissionDecision"] == "deny"
+      assert decoded["hookSpecificOutput"]["permissionDecisionReason"] == "Not allowed"
+    end
+
+    test "Jason.Encoder filters nil values" do
+      output = PreToolUse.Output.allow()
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      refute Map.has_key?(decoded, "stopReason")
+      refute Map.has_key?(decoded, "decision")
+      refute Map.has_key?(decoded, "reason")
+      refute Map.has_key?(decoded["hookSpecificOutput"], "permissionDecisionReason")
+    end
+
+    test "Jason.Encoder handles deprecated fields" do
+      output = %PreToolUse.Output{
+        continue: true,
+        decision: :approve,
+        reason: "Legacy reason"
+      }
+
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded["decision"] == "approve"
+      assert decoded["reason"] == "Legacy reason"
+    end
+  end
+end

--- a/test/claude/hooks/events/stop_test.exs
+++ b/test/claude/hooks/events/stop_test.exs
@@ -1,0 +1,137 @@
+defmodule Claude.Hooks.Events.StopTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events.Stop
+
+  describe "Input" do
+    test "new/1 creates struct from map" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "Stop",
+        "stop_hook_active" => true
+      }
+
+      input = Stop.Input.new(attrs)
+
+      assert input.session_id == "test-123"
+      assert input.transcript_path == "/path/to/transcript.jsonl"
+      assert input.hook_event_name == "Stop"
+      assert input.stop_hook_active == true
+    end
+
+    test "new/1 defaults stop_hook_active to false" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "Stop"
+      }
+
+      input = Stop.Input.new(attrs)
+      assert input.stop_hook_active == false
+    end
+
+    test "new/1 defaults hook_event_name if not provided" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl"
+      }
+
+      input = Stop.Input.new(attrs)
+      assert input.hook_event_name == "Stop"
+    end
+
+    test "from_json/1 parses valid JSON" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "hook_event_name": "Stop",
+        "stop_hook_active": true
+      })
+
+      {:ok, input} = Stop.Input.from_json(json)
+
+      assert input.session_id == "test-123"
+      assert input.stop_hook_active == true
+    end
+
+    test "from_json/1 handles invalid JSON" do
+      assert {:error, _} = Stop.Input.from_json("invalid json")
+    end
+
+    test "Jason.Encoder implementation encodes Input struct" do
+      input = %Stop.Input{
+        session_id: "test-123",
+        transcript_path: "/path/to/transcript.jsonl",
+        hook_event_name: "Stop",
+        stop_hook_active: false
+      }
+
+      json = Jason.encode!(input)
+      decoded = Jason.decode!(json)
+
+      assert decoded["session_id"] == "test-123"
+      assert decoded["stop_hook_active"] == false
+      # Note: Stop events don't have cwd field
+      refute Map.has_key?(decoded, "cwd")
+    end
+  end
+
+  describe "Output" do
+    test "allow/0 creates allow output" do
+      output = Stop.Output.allow()
+
+      assert output.continue == true
+      assert output.decision == nil
+      assert output.reason == nil
+    end
+
+    test "block/1 creates block decision output" do
+      output = Stop.Output.block("Tests are still running")
+
+      assert output.continue == true
+      assert output.decision == :block
+      assert output.reason == "Tests are still running"
+    end
+
+    test "output can be encoded to JSON string" do
+      output = Stop.Output.block("Build in progress")
+      json = Jason.encode!(output)
+
+      assert is_binary(json)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == true
+      assert decoded["decision"] == "block"
+      assert decoded["reason"] == "Build in progress"
+    end
+
+    test "Jason.Encoder implementation converts snake_case to camelCase" do
+      output = %Stop.Output{
+        continue: false,
+        stop_reason: "Force stop",
+        suppress_output: true,
+        decision: :block,
+        reason: "Cannot stop yet"
+      }
+
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == false
+      assert decoded["stopReason"] == "Force stop"
+      assert decoded["suppressOutput"] == true
+      assert decoded["decision"] == "block"
+      assert decoded["reason"] == "Cannot stop yet"
+    end
+
+    test "Jason.Encoder filters nil values" do
+      output = Stop.Output.allow()
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded == %{"continue" => true, "suppressOutput" => false}
+      refute Map.has_key?(decoded, "decision")
+      refute Map.has_key?(decoded, "reason")
+    end
+  end
+end

--- a/test/claude/hooks/events/subagent_stop_test.exs
+++ b/test/claude/hooks/events/subagent_stop_test.exs
@@ -1,0 +1,114 @@
+defmodule Claude.Hooks.Events.SubagentStopTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events.SubagentStop
+
+  describe "Input" do
+    test "new/1 creates struct from map" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "SubagentStop",
+        "stop_hook_active" => true
+      }
+
+      input = SubagentStop.Input.new(attrs)
+
+      assert input.session_id == "test-123"
+      assert input.transcript_path == "/path/to/transcript.jsonl"
+      assert input.hook_event_name == "SubagentStop"
+      assert input.stop_hook_active == true
+    end
+
+    test "new/1 defaults stop_hook_active to false" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "SubagentStop"
+      }
+
+      input = SubagentStop.Input.new(attrs)
+      assert input.stop_hook_active == false
+    end
+
+    test "new/1 defaults hook_event_name if not provided" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl"
+      }
+
+      input = SubagentStop.Input.new(attrs)
+      assert input.hook_event_name == "SubagentStop"
+    end
+
+    test "from_json/1 parses valid JSON" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "hook_event_name": "SubagentStop",
+        "stop_hook_active": false
+      })
+
+      {:ok, input} = SubagentStop.Input.from_json(json)
+
+      assert input.session_id == "test-123"
+      assert input.stop_hook_active == false
+    end
+
+    test "from_json/1 handles invalid JSON" do
+      assert {:error, _} = SubagentStop.Input.from_json("invalid json")
+    end
+
+    test "Jason.Encoder implementation encodes Input struct" do
+      input = %SubagentStop.Input{
+        session_id: "test-123",
+        transcript_path: "/path/to/transcript.jsonl",
+        hook_event_name: "SubagentStop",
+        stop_hook_active: true
+      }
+
+      json = Jason.encode!(input)
+      decoded = Jason.decode!(json)
+
+      assert decoded["session_id"] == "test-123"
+      assert decoded["stop_hook_active"] == true
+      # Note: SubagentStop events don't have cwd field
+      refute Map.has_key?(decoded, "cwd")
+    end
+  end
+
+  describe "Output" do
+    test "Output has same interface as Stop.Output" do
+      # SubagentStop.Output has the same interface as Stop.Output
+      output = SubagentStop.Output.allow()
+      assert %Claude.Hooks.Events.SubagentStop.Output{} = output
+    end
+
+    test "allow/0 creates allow output" do
+      output = SubagentStop.Output.allow()
+
+      assert output.continue == true
+      assert output.decision == nil
+      assert output.reason == nil
+    end
+
+    test "block/1 creates block decision output" do
+      output = SubagentStop.Output.block("Subagent task incomplete")
+
+      assert output.continue == true
+      assert output.decision == :block
+      assert output.reason == "Subagent task incomplete"
+    end
+
+    test "output can be encoded to JSON string" do
+      output = SubagentStop.Output.block("Still processing")
+      json = Jason.encode!(output)
+
+      assert is_binary(json)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == true
+      assert decoded["decision"] == "block"
+      assert decoded["reason"] == "Still processing"
+    end
+  end
+end

--- a/test/claude/hooks/events/user_prompt_submit_test.exs
+++ b/test/claude/hooks/events/user_prompt_submit_test.exs
@@ -1,0 +1,153 @@
+defmodule Claude.Hooks.Events.UserPromptSubmitTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events.UserPromptSubmit
+
+  describe "Input" do
+    test "new/1 creates struct from map" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "hook_event_name" => "UserPromptSubmit",
+        "prompt" => "Write a function to calculate factorial"
+      }
+
+      input = UserPromptSubmit.Input.new(attrs)
+
+      assert input.session_id == "test-123"
+      assert input.transcript_path == "/path/to/transcript.jsonl"
+      assert input.cwd == "/project"
+      assert input.hook_event_name == "UserPromptSubmit"
+      assert input.prompt == "Write a function to calculate factorial"
+    end
+
+    test "new/1 defaults hook_event_name if not provided" do
+      attrs = %{
+        "session_id" => "test-123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "prompt" => "Test prompt"
+      }
+
+      input = UserPromptSubmit.Input.new(attrs)
+      assert input.hook_event_name == "UserPromptSubmit"
+    end
+
+    test "from_json/1 parses valid JSON" do
+      json = ~s({
+        "session_id": "test-123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "cwd": "/project",
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Explain the code in this file"
+      })
+
+      {:ok, input} = UserPromptSubmit.Input.from_json(json)
+
+      assert input.session_id == "test-123"
+      assert input.prompt == "Explain the code in this file"
+    end
+
+    test "from_json/1 handles invalid JSON" do
+      assert {:error, _} = UserPromptSubmit.Input.from_json("invalid json")
+    end
+
+    test "Jason.Encoder implementation encodes Input struct" do
+      input = %UserPromptSubmit.Input{
+        session_id: "test-123",
+        transcript_path: "/path/to/transcript.jsonl",
+        cwd: "/project",
+        hook_event_name: "UserPromptSubmit",
+        prompt: "Test prompt"
+      }
+
+      json = Jason.encode!(input)
+      decoded = Jason.decode!(json)
+
+      assert decoded["session_id"] == "test-123"
+      assert decoded["prompt"] == "Test prompt"
+    end
+  end
+
+  describe "Output" do
+    test "allow/0 creates allow output" do
+      output = UserPromptSubmit.Output.allow()
+
+      assert output.continue == true
+      assert output.decision == nil
+      assert output.reason == nil
+      assert output.hook_specific_output == nil
+    end
+
+    test "allow_with_context/1 creates allow output with additional context" do
+      output = UserPromptSubmit.Output.allow_with_context("Current time: 2024-03-15")
+
+      assert output.continue == true
+      assert output.decision == nil
+      assert output.hook_specific_output.hook_event_name == "UserPromptSubmit"
+      assert output.hook_specific_output.additional_context == "Current time: 2024-03-15"
+    end
+
+    test "block/1 creates block decision output" do
+      output = UserPromptSubmit.Output.block("Prompt contains sensitive information")
+
+      assert output.continue == true
+      assert output.decision == :block
+      assert output.reason == "Prompt contains sensitive information"
+    end
+
+    test "output can be encoded to JSON string" do
+      output = UserPromptSubmit.Output.block("Invalid prompt")
+      json = Jason.encode!(output)
+
+      assert is_binary(json)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == true
+      assert decoded["decision"] == "block"
+      assert decoded["reason"] == "Invalid prompt"
+    end
+
+    test "Jason.Encoder implementation converts snake_case to camelCase" do
+      output = %UserPromptSubmit.Output{
+        continue: false,
+        stop_reason: "Security violation",
+        suppress_output: true,
+        hook_specific_output: %{
+          hook_event_name: "UserPromptSubmit",
+          additional_context: "Added context"
+        }
+      }
+
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == false
+      assert decoded["stopReason"] == "Security violation"
+      assert decoded["suppressOutput"] == true
+      assert decoded["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+      assert decoded["hookSpecificOutput"]["additionalContext"] == "Added context"
+    end
+
+    test "Jason.Encoder filters nil values" do
+      output = UserPromptSubmit.Output.allow()
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded == %{"continue" => true, "suppressOutput" => false}
+      refute Map.has_key?(decoded, "decision")
+      refute Map.has_key?(decoded, "reason")
+      refute Map.has_key?(decoded, "hookSpecificOutput")
+    end
+
+    test "Jason.Encoder handles context without blocking" do
+      output = UserPromptSubmit.Output.allow_with_context("Extra info")
+      json = Jason.encode!(output)
+      decoded = Jason.decode!(json)
+
+      assert decoded["continue"] == true
+      assert decoded["hookSpecificOutput"]["additionalContext"] == "Extra info"
+      refute Map.has_key?(decoded, "decision")
+    end
+  end
+end

--- a/test/claude/hooks/events_test.exs
+++ b/test/claude/hooks/events_test.exs
@@ -1,0 +1,309 @@
+defmodule Claude.Hooks.EventsTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events
+  alias Claude.Hooks.Events.Common
+
+  describe "PreToolUse" do
+    test "creates struct from map" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "hook_event_name" => "PreToolUse",
+        "tool_name" => "Edit",
+        "tool_input" => %{"file_path" => "/file.ex"}
+      }
+
+      event = Events.PreToolUse.Input.new(attrs)
+
+      assert event.session_id == "abc123"
+      assert event.transcript_path == "/path/to/transcript.jsonl"
+      assert event.cwd == "/project"
+      assert event.hook_event_name == "PreToolUse"
+      assert event.tool_name == "Edit"
+      assert %Claude.Hooks.ToolInputs.Edit{file_path: "/file.ex"} = event.tool_input
+    end
+
+    test "parses from JSON" do
+      json = ~s({
+        "session_id": "abc123",
+        "transcript_path": "/path/to/transcript.jsonl",
+        "cwd": "/project",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"file_path": "/file.ex"}
+      })
+
+      assert {:ok, event} = Events.PreToolUse.Input.from_json(json)
+      assert event.tool_name == "Edit"
+      assert event.tool_input.file_path == "/file.ex"
+    end
+
+    test "handles missing optional fields" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "tool_name" => "Edit"
+      }
+
+      event = Events.PreToolUse.Input.new(attrs)
+      assert event.hook_event_name == "PreToolUse"
+      assert %Claude.Hooks.ToolInputs.Edit{file_path: nil} = event.tool_input
+    end
+
+    test "returns raw map for unknown tools" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "tool_name" => "UnknownTool",
+        "tool_input" => %{"some" => "data", "other" => "value"}
+      }
+
+      event = Events.PreToolUse.Input.new(attrs)
+      assert event.tool_name == "UnknownTool"
+      assert event.tool_input == %{"some" => "data", "other" => "value"}
+    end
+  end
+
+  describe "PostToolUse" do
+    test "creates struct from map with tool response" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "hook_event_name" => "PostToolUse",
+        "tool_name" => "Write",
+        "tool_input" => %{"file_path" => "/file.ex", "content" => "defmodule Test do\nend"},
+        "tool_response" => %{"filePath" => "/file.ex", "success" => true}
+      }
+
+      event = Events.PostToolUse.Input.new(attrs)
+
+      assert event.tool_name == "Write"
+      assert event.tool_response["success"] == true
+    end
+  end
+
+  describe "Notification" do
+    test "creates struct from map" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "hook_event_name" => "Notification",
+        "message" => "Claude needs your permission to use Bash"
+      }
+
+      event = Events.Notification.Input.new(attrs)
+      assert event.message == "Claude needs your permission to use Bash"
+    end
+  end
+
+  describe "UserPromptSubmit" do
+    test "creates struct from map" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "cwd" => "/project",
+        "hook_event_name" => "UserPromptSubmit",
+        "prompt" => "Write a function to calculate factorial"
+      }
+
+      event = Events.UserPromptSubmit.Input.new(attrs)
+      assert event.prompt == "Write a function to calculate factorial"
+    end
+  end
+
+  describe "Stop" do
+    test "creates struct from map" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "Stop",
+        "stop_hook_active" => true
+      }
+
+      event = Events.Stop.Input.new(attrs)
+      assert event.stop_hook_active == true
+    end
+
+    test "defaults stop_hook_active to false" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "Stop"
+      }
+
+      event = Events.Stop.Input.new(attrs)
+      assert event.stop_hook_active == false
+    end
+  end
+
+  describe "PreCompact" do
+    test "creates struct with manual trigger" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "PreCompact",
+        "trigger" => "manual",
+        "custom_instructions" => "Keep error handling code"
+      }
+
+      event = Events.PreCompact.Input.new(attrs)
+      assert event.trigger == :manual
+      assert event.custom_instructions == "Keep error handling code"
+    end
+
+    test "creates struct with auto trigger" do
+      attrs = %{
+        "session_id" => "abc123",
+        "transcript_path" => "/path/to/transcript.jsonl",
+        "hook_event_name" => "PreCompact",
+        "trigger" => "auto"
+      }
+
+      event = Events.PreCompact.Input.new(attrs)
+      assert event.trigger == :auto
+      assert event.custom_instructions == ""
+    end
+  end
+
+  describe "parse_hook_input/1" do
+    test "parses PreToolUse event" do
+      json = ~s({
+        "hook_event_name": "PreToolUse",
+        "session_id": "abc123",
+        "tool_name": "Edit"
+      })
+
+      assert {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.PreToolUse.Input{} = event
+      assert event.tool_name == "Edit"
+    end
+
+    test "parses PostToolUse event" do
+      json = ~s({
+        "hook_event_name": "PostToolUse",
+        "session_id": "abc123",
+        "tool_name": "Write",
+        "tool_response": {"success": true}
+      })
+
+      assert {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.PostToolUse.Input{} = event
+      assert event.tool_response["success"] == true
+    end
+
+    test "parses Notification event" do
+      json = ~s({
+        "hook_event_name": "Notification",
+        "session_id": "abc123",
+        "message": "Test notification"
+      })
+
+      assert {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.Notification.Input{} = event
+      assert event.message == "Test notification"
+    end
+
+    test "parses UserPromptSubmit event" do
+      json = ~s({
+        "hook_event_name": "UserPromptSubmit",
+        "session_id": "abc123",
+        "prompt": "Test prompt"
+      })
+
+      assert {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.UserPromptSubmit.Input{} = event
+      assert event.prompt == "Test prompt"
+    end
+
+    test "parses Stop event" do
+      json = ~s({
+        "hook_event_name": "Stop",
+        "session_id": "abc123",
+        "stop_hook_active": false
+      })
+
+      assert {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.Stop.Input{} = event
+      assert event.stop_hook_active == false
+    end
+
+    test "parses SubagentStop event" do
+      json = ~s({
+        "hook_event_name": "SubagentStop",
+        "session_id": "abc123",
+        "stop_hook_active": true
+      })
+
+      assert {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.SubagentStop.Input{} = event
+      assert event.stop_hook_active == true
+    end
+
+    test "parses PreCompact event" do
+      json = ~s({
+        "hook_event_name": "PreCompact",
+        "session_id": "abc123",
+        "trigger": "manual"
+      })
+
+      assert {:ok, event} = Common.parse_hook_input(json)
+      assert %Events.PreCompact.Input{} = event
+      assert event.trigger == :manual
+    end
+
+    test "returns error for unknown event" do
+      json = ~s({
+        "hook_event_name": "UnknownEvent",
+        "session_id": "abc123"
+      })
+
+      assert {:error, "Unknown hook event name: \"UnknownEvent\""} = Common.parse_hook_input(json)
+    end
+
+    test "returns error for invalid JSON" do
+      assert {:error, _} = Common.parse_hook_input("invalid json")
+    end
+  end
+
+  describe "Jason.Encoder" do
+    test "encodes PreToolUse to JSON" do
+      event = %Events.PreToolUse.Input{
+        session_id: "abc123",
+        tool_name: "Edit",
+        tool_input: %{"file_path" => "/test.ex"}
+      }
+
+      assert {:ok, json} = Jason.encode(event)
+      assert json =~ ~s("session_id":"abc123")
+      assert json =~ ~s("tool_name":"Edit")
+    end
+
+    test "encodes PostToolUse to JSON" do
+      event = %Events.PostToolUse.Input{
+        session_id: "abc123",
+        tool_name: "Write",
+        tool_response: %{"success" => true}
+      }
+
+      assert {:ok, json} = Jason.encode(event)
+      assert json =~ ~s("tool_response":{"success":true})
+    end
+
+    test "encodes PreCompact with atom trigger to JSON" do
+      event = %Events.PreCompact.Input{
+        session_id: "abc123",
+        trigger: :manual,
+        custom_instructions: "Keep errors"
+      }
+
+      assert {:ok, json} = Jason.encode(event)
+      assert json =~ ~s("trigger":"manual")
+      assert json =~ ~s("custom_instructions":"Keep errors")
+    end
+  end
+end

--- a/test/claude/hooks/outputs_test.exs
+++ b/test/claude/hooks/outputs_test.exs
@@ -1,0 +1,159 @@
+defmodule Claude.Hooks.OutputsTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.Events
+  alias Claude.Hooks.Events.Common
+
+  describe "PreToolUseOutput" do
+    test "creates allow output" do
+      output = Events.PreToolUse.Output.allow("Auto-approved for documentation")
+
+      assert output.hook_specific_output.permission_decision == :allow
+
+      assert output.hook_specific_output.permission_decision_reason ==
+               "Auto-approved for documentation"
+    end
+
+    test "creates deny output" do
+      output = Events.PreToolUse.Output.deny("Dangerous operation detected")
+
+      assert output.hook_specific_output.permission_decision == :deny
+      assert output.hook_specific_output.permission_decision_reason == "Dangerous operation detected"
+    end
+
+    test "creates ask output" do
+      output = Events.PreToolUse.Output.ask("User confirmation required")
+
+      assert output.hook_specific_output.permission_decision == :ask
+      assert output.hook_specific_output.permission_decision_reason == "User confirmation required"
+    end
+
+    test "converts to JSON with permission decision" do
+      output = Events.PreToolUse.Output.allow("Test reason")
+
+      json = Jason.encode!(output)
+      assert json =~ ~s("permissionDecision":"allow")
+      assert json =~ ~s("permissionDecisionReason":"Test reason")
+    end
+
+    test "converts to JSON excluding nil fields" do
+      output = %Events.PreToolUse.Output{
+        continue: false,
+        stop_reason: "Test stop"
+      }
+
+      json = Jason.encode!(output)
+      refute json =~ "hookSpecificOutput"
+      refute json =~ "decision"
+      assert json =~ ~s("continue":false)
+      assert json =~ ~s("stopReason":"Test stop")
+    end
+  end
+
+  describe "PostToolUseOutput" do
+    test "creates block output" do
+      output = Events.PostToolUse.Output.block("Compilation error detected")
+
+      assert output.decision == :block
+      assert output.reason == "Compilation error detected"
+    end
+
+    test "creates allow output" do
+      output = Events.PostToolUse.Output.allow()
+
+      assert output.decision == nil
+      assert output.reason == nil
+      assert output.continue == true
+    end
+
+    test "converts to JSON" do
+      output = Events.PostToolUse.Output.block("Test reason")
+
+      json = Jason.encode!(output)
+      assert json =~ ~s("decision":"block")
+      assert json =~ ~s("reason":"Test reason")
+    end
+  end
+
+  describe "UserPromptSubmitOutput" do
+    test "creates block output" do
+      output = Events.UserPromptSubmit.Output.block("Sensitive content detected")
+
+      assert output.decision == :block
+      assert output.reason == "Sensitive content detected"
+    end
+
+    test "creates add context output" do
+      output = Events.UserPromptSubmit.Output.add_context("Current time: 2024-01-01")
+
+      assert output.hook_specific_output.additional_context == "Current time: 2024-01-01"
+      assert output.decision == nil
+    end
+
+    test "converts to JSON with context" do
+      output = Events.UserPromptSubmit.Output.add_context("Test context")
+
+      json = Jason.encode!(output)
+      assert json =~ ~s("additionalContext":"Test context")
+      assert json =~ ~s("hookEventName":"UserPromptSubmit")
+    end
+  end
+
+  describe "StopOutput" do
+    test "creates block output" do
+      output = Events.Stop.Output.block("More tasks to complete")
+
+      assert output.decision == :block
+      assert output.reason == "More tasks to complete"
+    end
+
+    test "creates allow output" do
+      output = Events.Stop.Output.allow()
+
+      assert output.decision == nil
+      assert output.continue == true
+    end
+
+    test "converts to JSON" do
+      output = Events.Stop.Output.block("Continue processing")
+
+      json = Jason.encode!(output)
+      assert json =~ ~s("decision":"block")
+      assert json =~ ~s("reason":"Continue processing")
+    end
+  end
+
+  describe "SimpleOutput" do
+    test "creates success output" do
+      output = Common.SimpleOutput.success("Operation completed")
+
+      assert output.exit_code == 0
+      assert output.stdout == "Operation completed"
+      assert output.stderr == nil
+    end
+
+    test "creates block output" do
+      output = Common.SimpleOutput.block("Invalid operation")
+
+      assert output.exit_code == 2
+      assert output.stderr == "Invalid operation"
+      assert output.stdout == nil
+    end
+
+    test "creates error output" do
+      output = Common.SimpleOutput.error("Non-critical error", 3)
+
+      assert output.exit_code == 3
+      assert output.stderr == "Non-critical error"
+    end
+
+    test "error rejects exit codes 0 and 2" do
+      assert_raise FunctionClauseError, fn ->
+        Common.SimpleOutput.error("Test", 0)
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        Common.SimpleOutput.error("Test", 2)
+      end
+    end
+  end
+end

--- a/test/claude/hooks/tool_inputs_test.exs
+++ b/test/claude/hooks/tool_inputs_test.exs
@@ -1,0 +1,439 @@
+defmodule Claude.Hooks.ToolInputsTest do
+  use ExUnit.Case, async: true
+  alias Claude.Hooks.ToolInputs
+
+  describe "Task" do
+    test "creates struct from map" do
+      attrs = %{
+        "description" => "Find and fix bugs",
+        "prompt" => "Search for compilation errors in the codebase"
+      }
+
+      task = ToolInputs.Task.new(attrs)
+
+      assert task.description == "Find and fix bugs"
+      assert task.prompt == "Search for compilation errors in the codebase"
+    end
+  end
+
+  describe "Bash" do
+    test "creates struct from map with all fields" do
+      attrs = %{
+        "command" => "mix test",
+        "description" => "Run tests",
+        "timeout" => 30000
+      }
+
+      bash = ToolInputs.Bash.new(attrs)
+
+      assert bash.command == "mix test"
+      assert bash.description == "Run tests"
+      assert bash.timeout == 30000
+    end
+
+    test "handles missing optional fields" do
+      attrs = %{"command" => "ls"}
+
+      bash = ToolInputs.Bash.new(attrs)
+
+      assert bash.command == "ls"
+      assert bash.description == nil
+      assert bash.timeout == nil
+    end
+  end
+
+  describe "Edit" do
+    test "creates struct from map" do
+      attrs = %{
+        "file_path" => "/test.ex",
+        "old_string" => "def hello",
+        "new_string" => "def hello_world",
+        "replace_all" => true
+      }
+
+      edit = ToolInputs.Edit.new(attrs)
+
+      assert edit.file_path == "/test.ex"
+      assert edit.old_string == "def hello"
+      assert edit.new_string == "def hello_world"
+      assert edit.replace_all == true
+    end
+
+    test "defaults replace_all to false" do
+      attrs = %{
+        "file_path" => "/test.ex",
+        "old_string" => "old",
+        "new_string" => "new"
+      }
+
+      edit = ToolInputs.Edit.new(attrs)
+      assert edit.replace_all == false
+    end
+  end
+
+  describe "MultiEdit" do
+    test "creates struct with multiple edits" do
+      attrs = %{
+        "file_path" => "/test.ex",
+        "edits" => [
+          %{"old_string" => "foo", "new_string" => "bar", "replace_all" => true},
+          %{"old_string" => "baz", "new_string" => "qux"}
+        ]
+      }
+
+      multi_edit = ToolInputs.MultiEdit.new(attrs)
+
+      assert multi_edit.file_path == "/test.ex"
+      assert length(multi_edit.edits) == 2
+      assert hd(multi_edit.edits) == %{old_string: "foo", new_string: "bar", replace_all: true}
+
+      assert List.last(multi_edit.edits) == %{
+               old_string: "baz",
+               new_string: "qux",
+               replace_all: false
+             }
+    end
+
+    test "handles empty edits list" do
+      attrs = %{"file_path" => "/test.ex"}
+
+      multi_edit = ToolInputs.MultiEdit.new(attrs)
+      assert multi_edit.edits == []
+    end
+  end
+
+  describe "Write" do
+    test "creates struct from map" do
+      attrs = %{
+        "file_path" => "/new_file.ex",
+        "content" => "defmodule NewFile do\nend"
+      }
+
+      write = ToolInputs.Write.new(attrs)
+
+      assert write.file_path == "/new_file.ex"
+      assert write.content == "defmodule NewFile do\nend"
+    end
+  end
+
+  describe "Read" do
+    test "creates struct with all fields" do
+      attrs = %{
+        "file_path" => "/test.ex",
+        "limit" => 100,
+        "offset" => 50
+      }
+
+      read = ToolInputs.Read.new(attrs)
+
+      assert read.file_path == "/test.ex"
+      assert read.limit == 100
+      assert read.offset == 50
+    end
+
+    test "handles missing optional fields" do
+      attrs = %{"file_path" => "/test.ex"}
+
+      read = ToolInputs.Read.new(attrs)
+
+      assert read.file_path == "/test.ex"
+      assert read.limit == nil
+      assert read.offset == nil
+    end
+  end
+
+  describe "Glob" do
+    test "creates struct from map" do
+      attrs = %{
+        "path" => "/src",
+        "pattern" => "**/*.ex"
+      }
+
+      glob = ToolInputs.Glob.new(attrs)
+
+      assert glob.path == "/src"
+      assert glob.pattern == "**/*.ex"
+    end
+
+    test "handles missing path" do
+      attrs = %{"pattern" => "*.txt"}
+
+      glob = ToolInputs.Glob.new(attrs)
+
+      assert glob.path == nil
+      assert glob.pattern == "*.txt"
+    end
+  end
+
+  describe "Grep" do
+    test "creates struct with all fields" do
+      attrs = %{
+        "pattern" => "TODO",
+        "path" => "/src",
+        "type" => "elixir",
+        "glob" => "*.ex",
+        "output_mode" => "content",
+        "head_limit" => 20,
+        "multiline" => true,
+        "-A" => 2,
+        "-B" => 2,
+        "-C" => 3,
+        "-i" => true,
+        "-n" => true
+      }
+
+      grep = ToolInputs.Grep.new(attrs)
+
+      assert grep.pattern == "TODO"
+      assert grep.path == "/src"
+      assert grep.type == "elixir"
+      assert grep.glob == "*.ex"
+      assert grep.output_mode == :content
+      assert grep.head_limit == 20
+      assert grep.multiline == true
+      assert Map.get(grep, :"-A") == 2
+      assert Map.get(grep, :"-B") == 2
+      assert Map.get(grep, :"-C") == 3
+      assert Map.get(grep, :"-i") == true
+      assert Map.get(grep, :"-n") == true
+    end
+
+    test "parses output_mode correctly" do
+      assert ToolInputs.Grep.new(%{"pattern" => "test", "output_mode" => "content"}).output_mode ==
+               :content
+
+      assert ToolInputs.Grep.new(%{"pattern" => "test", "output_mode" => "files_with_matches"}).output_mode ==
+               :files_with_matches
+
+      assert ToolInputs.Grep.new(%{"pattern" => "test", "output_mode" => "count"}).output_mode ==
+               :count
+
+      assert ToolInputs.Grep.new(%{"pattern" => "test", "output_mode" => "invalid"}).output_mode ==
+               :files_with_matches
+    end
+  end
+
+  describe "LS" do
+    test "creates struct from map" do
+      attrs = %{
+        "path" => "/home/user",
+        "ignore" => [".git", "node_modules"]
+      }
+
+      ls = ToolInputs.LS.new(attrs)
+
+      assert ls.path == "/home/user"
+      assert ls.ignore == [".git", "node_modules"]
+    end
+  end
+
+  describe "NotebookRead" do
+    test "creates struct from map" do
+      attrs = %{
+        "notebook_path" => "/notebook.ipynb",
+        "cell_id" => "cell_123"
+      }
+
+      notebook_read = ToolInputs.NotebookRead.new(attrs)
+
+      assert notebook_read.notebook_path == "/notebook.ipynb"
+      assert notebook_read.cell_id == "cell_123"
+    end
+  end
+
+  describe "NotebookEdit" do
+    test "creates struct with all fields" do
+      attrs = %{
+        "notebook_path" => "/notebook.ipynb",
+        "new_source" => "print('Hello')",
+        "cell_id" => "cell_123",
+        "cell_type" => "code",
+        "edit_mode" => "replace"
+      }
+
+      notebook_edit = ToolInputs.NotebookEdit.new(attrs)
+
+      assert notebook_edit.notebook_path == "/notebook.ipynb"
+      assert notebook_edit.new_source == "print('Hello')"
+      assert notebook_edit.cell_id == "cell_123"
+      assert notebook_edit.cell_type == :code
+      assert notebook_edit.edit_mode == :replace
+    end
+
+    test "parses cell_type and edit_mode correctly" do
+      assert ToolInputs.NotebookEdit.new(%{
+               "notebook_path" => "n.ipynb",
+               "new_source" => "x",
+               "cell_type" => "code"
+             }).cell_type == :code
+
+      assert ToolInputs.NotebookEdit.new(%{
+               "notebook_path" => "n.ipynb",
+               "new_source" => "x",
+               "cell_type" => "markdown"
+             }).cell_type == :markdown
+
+      assert ToolInputs.NotebookEdit.new(%{
+               "notebook_path" => "n.ipynb",
+               "new_source" => "x",
+               "edit_mode" => "insert"
+             }).edit_mode == :insert
+
+      assert ToolInputs.NotebookEdit.new(%{
+               "notebook_path" => "n.ipynb",
+               "new_source" => "x",
+               "edit_mode" => "delete"
+             }).edit_mode == :delete
+    end
+  end
+
+  describe "WebFetch" do
+    test "creates struct from map" do
+      attrs = %{
+        "url" => "https://example.com",
+        "prompt" => "Extract the main content"
+      }
+
+      web_fetch = ToolInputs.WebFetch.new(attrs)
+
+      assert web_fetch.url == "https://example.com"
+      assert web_fetch.prompt == "Extract the main content"
+    end
+  end
+
+  describe "WebSearch" do
+    test "creates struct from map" do
+      attrs = %{
+        "query" => "elixir documentation",
+        "allowed_domains" => ["hexdocs.pm"],
+        "blocked_domains" => ["spam.com"]
+      }
+
+      web_search = ToolInputs.WebSearch.new(attrs)
+
+      assert web_search.query == "elixir documentation"
+      assert web_search.allowed_domains == ["hexdocs.pm"]
+      assert web_search.blocked_domains == ["spam.com"]
+    end
+  end
+
+  describe "TodoWrite" do
+    test "creates struct with todos" do
+      attrs = %{
+        "todos" => [
+          %{
+            "content" => "Fix bug",
+            "status" => "in_progress",
+            "priority" => "high",
+            "id" => "1"
+          },
+          %{
+            "content" => "Write tests",
+            "status" => "pending",
+            "priority" => "medium",
+            "id" => "2"
+          }
+        ]
+      }
+
+      todo_write = ToolInputs.TodoWrite.new(attrs)
+
+      assert length(todo_write.todos) == 2
+
+      first_todo = hd(todo_write.todos)
+      assert first_todo.content == "Fix bug"
+      assert first_todo.status == :in_progress
+      assert first_todo.priority == :high
+      assert first_todo.id == "1"
+
+      second_todo = List.last(todo_write.todos)
+      assert second_todo.content == "Write tests"
+      assert second_todo.status == :pending
+      assert second_todo.priority == :medium
+      assert second_todo.id == "2"
+    end
+
+    test "handles invalid status and priority" do
+      attrs = %{
+        "todos" => [
+          %{
+            "content" => "Task",
+            "status" => "invalid",
+            "priority" => "invalid",
+            "id" => "1"
+          }
+        ]
+      }
+
+      todo_write = ToolInputs.TodoWrite.new(attrs)
+      todo = hd(todo_write.todos)
+
+      # default
+      assert todo.status == :pending
+      # default
+      assert todo.priority == :medium
+    end
+  end
+
+  describe "parse_tool_input/2" do
+    test "parses Write tool input" do
+      tool_input = %{"file_path" => "/test.ex", "content" => "defmodule Test do\nend"}
+
+      assert {:ok, input} = ToolInputs.parse_tool_input("Write", tool_input)
+      assert %ToolInputs.Write{file_path: "/test.ex"} = input
+    end
+
+    test "parses Edit tool input" do
+      tool_input = %{
+        "file_path" => "/test.ex",
+        "old_string" => "old",
+        "new_string" => "new"
+      }
+
+      assert {:ok, input} = ToolInputs.parse_tool_input("Edit", tool_input)
+      assert %ToolInputs.Edit{file_path: "/test.ex"} = input
+    end
+
+    test "parses Bash tool input" do
+      tool_input = %{"command" => "mix test"}
+
+      assert {:ok, input} = ToolInputs.parse_tool_input("Bash", tool_input)
+      assert %ToolInputs.Bash{command: "mix test"} = input
+    end
+
+    test "returns raw map for unknown tools" do
+      tool_input = %{"some" => "data"}
+
+      assert {:ok, input} = ToolInputs.parse_tool_input("UnknownTool", tool_input)
+      assert input == %{"some" => "data"}
+    end
+
+    test "parses all known tools" do
+      tools = [
+        {"Task", %{"description" => "d", "prompt" => "p"}, ToolInputs.Task},
+        {"Bash", %{"command" => "ls"}, ToolInputs.Bash},
+        {"Edit", %{"file_path" => "f", "old_string" => "o", "new_string" => "n"},
+         ToolInputs.Edit},
+        {"MultiEdit", %{"file_path" => "f", "edits" => []}, ToolInputs.MultiEdit},
+        {"Write", %{"file_path" => "f", "content" => "c"}, ToolInputs.Write},
+        {"Read", %{"file_path" => "f"}, ToolInputs.Read},
+        {"Glob", %{"pattern" => "*.ex"}, ToolInputs.Glob},
+        {"Grep", %{"pattern" => "TODO"}, ToolInputs.Grep},
+        {"LS", %{"path" => "/"}, ToolInputs.LS},
+        {"NotebookRead", %{"notebook_path" => "n.ipynb"}, ToolInputs.NotebookRead},
+        {"NotebookEdit", %{"notebook_path" => "n.ipynb", "new_source" => "s"},
+         ToolInputs.NotebookEdit},
+        {"WebFetch", %{"url" => "http://example.com", "prompt" => "p"}, ToolInputs.WebFetch},
+        {"WebSearch", %{"query" => "elixir"}, ToolInputs.WebSearch},
+        {"TodoWrite", %{"todos" => []}, ToolInputs.TodoWrite}
+      ]
+
+      for {tool_name, tool_input, expected_module} <- tools do
+        assert {:ok, input} = ToolInputs.parse_tool_input(tool_name, tool_input)
+
+        assert match?(%^expected_module{}, input),
+               "Expected #{inspect(expected_module)} for #{tool_name}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR introduces properly structured Elixir modules for handling Claude Code hook inputs and outputs, providing a type-safe and idiomatic way to work with hook events.

## Core Changes

### Event Structures
- Created dedicated Input/Output structs for each hook event type:
  - PreToolUse / PostToolUse
  - Notification
  - UserPromptSubmit
  - Stop / SubagentStop
  - PreCompact
- Implemented automatic JSON parsing with proper Elixir conventions
- Added Jason.Encoder protocol implementations for all output structs

### Tool Input Parsing
- Added typed structs for all Claude Code tools (Bash, Edit, Write, Read, etc.)
- Integrated automatic tool input parsing into PreToolUse and PostToolUse events
- Provides type-safe access to tool parameters

### Module Organization
- Refactored to colocate Input/Output structs within their event modules (e.g., `Claude.Hooks.Events.PreToolUse.Input`)
- Moved JsonUtils to `Claude.Core` namespace for broader usage
- Removed redundant `to_json` functions in favor of standard `Jason.encode\!`

### Key Features
- All struct fields use `snake_case` internally (Elixir convention)
- JSON output automatically converts to `camelCase` for API compatibility
- Nil values are filtered from JSON output
- Comprehensive test coverage for all modules (287 tests, all passing)

## Example Usage

```elixir
# Parse hook input
{:ok, event} = Claude.Hooks.Events.Common.parse_hook_input(json_input)

# Pattern match on typed tool inputs
case event do
  %PreToolUse.Input{tool_input: %ToolInputs.Bash{command: cmd}} ->
    # Handle bash command with type safety
    
  %PreToolUse.Input{tool_input: %ToolInputs.Write{file_path: path, content: content}} ->
    # Handle file write with typed fields
end

# Create output responses
output = PreToolUse.Output.allow("Auto-approved for documentation files")
json = Jason.encode\!(output)
```

## Test Plan

- ✅ All existing tests pass
- ✅ Added comprehensive unit tests for all new modules
- ✅ JSON encoding/decoding verified for all event types
- ✅ Tool input parsing tested for all tool types
- ✅ No compilation warnings

🤖 Generated with [Claude Code](https://claude.ai/code)