### PR TITLE
Add usage rules documentation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule Claude.MixProject do
         "GitHub" => "https://github.com/bradleygolden/claude"
       },
       maintainers: ["Bradley Golden"],
-      files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md)
+      files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md usage-rules.md)
     ]
   end
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -1,0 +1,130 @@
+# Claude Usage Rules
+
+Claude (not to be confused with Claude/Claude Code) is an Elixir library that provides opinionated Claude Code integration for Elixir projects. It includes tooling for deeply integrating Claude Code into your project using Elixir.
+
+## Installation
+
+Claude only supports igniter installation:
+
+```bash
+mix igniter.install claude
+```
+
+## Uninstalling hooks
+
+Optionally you can uninstall the project:
+
+```bash
+mix claude.uninstall
+```
+
+This removes all settings created by this project from your project settings.
+
+## Hook System
+
+Claude provides a behavior-based hook system that integrates with Claude Code. All hooks implement `Claude.Hooks.Hook.Behaviour`.
+
+### Built-in Hooks
+
+1. **ElixirFormatter** - Automatically formats .ex/.exs files after edits
+2. **CompilationChecker** - Checks for compilation errors after edits
+3. **PreCommitCheck** - Validates formatting, compilation, and unused dependencies before commits
+
+### Creating Custom Hooks
+
+The easiest way to create a hook is using the `use` macro:
+
+```elixir
+defmodule MyProject.MyHook do
+  use Claude.Hooks.Hook.Behaviour,
+    event: :post_tool_use,
+    matcher: [:edit, :write],
+    description: "My custom hook that runs after edits"
+
+  @impl Claude.Hooks.Hook.Behaviour
+  def run(json_input) when is_binary(json_input) do
+    # Your hook logic here
+    :ok
+  end
+end
+```
+
+#### Options for `use` macro:
+
+- `:event` - Hook event type (default: `:post_tool_use`)
+  - `:pre_tool_use`
+  - `:post_tool_use`
+  - `:user_prompt_submit`
+  - `:notification`
+  - `:stop`
+  - `:subagent_stop`
+- `:matcher` - Tool matcher pattern (default: `:*`)
+  - Can be a single atom: `:edit`, `:write`, `:bash`
+  - Can be a list: `[:edit, :write, :multi_edit]`
+  - Can be `:*` to match all tools
+- `:description` - Human-readable description
+
+For more documentation about hooks see official documentation below:
+
+  * https://docs.anthropic.com/en/docs/claude-code/hooks
+  * https://docs.anthropic.com/en/docs/claude-code/hooks-guide
+
+ALWAYS consult the official documentation before implementing custom hooks.
+
+#### Manual Implementation
+
+If you need more control, you can implement the behaviour manually:
+
+```elixir
+defmodule MyProject.MyHook do
+  @behaviour Claude.Hooks.Hook.Behaviour
+
+  @impl true
+  def config do
+    %Claude.Hooks.Hook{
+      type: "command",
+      command: "cd $CLAUDE_PROJECT_DIR && mix claude hooks run #{identifier()}"
+    }
+  end
+
+  @impl true
+  def run(json_input) when is_binary(json_input) do
+    # Your hook logic here
+    :ok
+  end
+
+  @impl true
+  def description do
+    "My custom hook description"
+  end
+
+  defp identifier do
+    __MODULE__
+    |> Module.split()
+    |> Enum.map(&Macro.underscore/1)
+    |> Enum.join(".")
+  end
+end
+```
+
+## Settings Management
+
+Claude uses `.claude.exs` to configure specific settings for your project that are then ported to
+the `.claude` directory for use by Claude Code.
+
+### Example `.claude.exs` configuration:
+
+```elixir
+# .claude.exs - Claude configuration for this project
+%{
+  # Register custom hooks (for discovery by mix claude.install)
+  hooks: [
+    MyProject.Hooks.CustomFormatter,
+    MyProject.Hooks.SecurityChecker
+  ]
+}
+```
+
+For reference to the official claude settings, please see:
+
+ * https://docs.anthropic.com/en/docs/claude-code/settings


### PR DESCRIPTION
## Summary
- Add comprehensive `usage-rules.md` file for LLM guidance
- Document the hook system including the `use` macro approach
- Document settings management with `.claude.exs`
- Update package files to include usage rules in hex distribution

## Details

This PR adds usage rules documentation following the [usage_rules](https://github.com/ash-project/usage_rules) pattern. The documentation helps LLMs (and developers) understand how to properly use the Claude library.

### Key documentation added:
1. **Hook System** - How to create custom hooks using the `use` macro
2. **Settings Management** - How to configure Claude using `.claude.exs`
3. **Built-in Hooks** - Description of ElixirFormatter, CompilationChecker, and PreCommitCheck
4. **Installation** - Clear instructions on using igniter for installation

The usage rules are intentionally concise and direct LLM users to the official Claude Code documentation for deeper details.

## Test plan
- [x] Verify usage-rules.md is properly formatted
- [x] Ensure mix.exs includes usage-rules.md in package files
- [ ] Test that `mix hex.build` includes the usage rules file

🤖 Generated with [Claude Code](https://claude.ai/code)