### PR TITLE
Fix claude.install task to handle existing .claude.exs files

### DIFF
--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -44,18 +44,29 @@ defmodule Mix.Tasks.Claude.Install do
     claude_exs_path = Path.join(Project.root(), ".claude.exs")
     relative_exs_path = Path.relative_to_cwd(claude_exs_path)
 
+    igniter =
+      if File.exists?(claude_exs_path) do
+        igniter
+        |> Igniter.add_notice("""
+        Claude configuration file already exists at #{relative_exs_path}
+        Skipping file creation to preserve your existing configuration.
+        """)
+      else
+        igniter
+        |> Igniter.create_new_file(relative_exs_path, ConfigTemplate.claude_exs_content())
+        |> Igniter.add_notice("""
+        Claude has been configured for your project!
+
+        Configuration file created at #{relative_exs_path}
+        You can customize Claude's behavior by editing this file.
+        """)
+      end
+
     igniter
-    |> Igniter.create_new_file(relative_exs_path, ConfigTemplate.claude_exs_content())
     |> Igniter.Project.Deps.add_dep({:usage_rules, "~> 0.1", only: [:dev]}, on_exists: :skip)
     |> Igniter.compose_task("claude.hooks.install", [])
     |> Igniter.compose_task("claude.usage_rules.sync", [])
     |> Igniter.compose_task("claude.subagents.generate", [])
-    |> Igniter.add_notice("""
-    Claude has been configured for your project!
-
-    Configuration file created at #{relative_exs_path}
-    You can customize Claude's behavior by editing this file.
-    """)
   end
 
   @impl Igniter.Mix.Task


### PR DESCRIPTION
## Summary
- Fixed `mix claude.install` task failing when `.claude.exs` already exists
- Made the task idempotent so it can be run multiple times safely
- Preserves existing configuration files instead of overwriting them

## Test plan
1. Run `mix claude.install` on a fresh project - should create `.claude.exs`
2. Run `mix claude.install` again - should skip file creation with notice
3. Verify existing `.claude.exs` files are preserved

🤖 Generated with [Claude Code](https://claude.ai/code)