### PR TITLE
Fix Claude hooks path issues and remove unnecessary Igniter dependency

### DIFF
--- a/.claude/hooks/compilation_checker.exs
+++ b/.claude/hooks/compilation_checker.exs
@@ -3,7 +3,7 @@
 # This script is called with JSON input via stdin from Claude Code
 
 # Install dependencies
-Mix.install([{:claude, path: "../.."}, {:jason, "~> 1.4"}, {:igniter, "~> 0.6"}])
+Mix.install([{:claude, path: "."}, {:jason, "~> 1.4"}])
 
 # Read JSON from stdin
 input = IO.read(:stdio, :eof)

--- a/.claude/hooks/elixir_formatter.exs
+++ b/.claude/hooks/elixir_formatter.exs
@@ -3,7 +3,7 @@
 # This script is called with JSON input via stdin from Claude Code
 
 # Install dependencies
-Mix.install([{:claude, path: "../.."}, {:jason, "~> 1.4"}, {:igniter, "~> 0.6"}])
+Mix.install([{:claude, path: "."}, {:jason, "~> 1.4"}])
 
 # Read JSON from stdin
 input = IO.read(:stdio, :eof)

--- a/.claude/hooks/pre_commit_check.exs
+++ b/.claude/hooks/pre_commit_check.exs
@@ -3,7 +3,7 @@
 # This script is called with JSON input via stdin from Claude Code
 
 # Install dependencies
-Mix.install([{:claude, path: "../.."}, {:jason, "~> 1.4"}, {:igniter, "~> 0.6"}])
+Mix.install([{:claude, path: "."}, {:jason, "~> 1.4"}])
 
 # Read JSON from stdin
 input = IO.read(:stdio, :eof)

--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -46,10 +46,10 @@ defmodule Mix.Tasks.Claude.Install do
     #   MyProject.Hooks.CustomFormatter,
     #   MyProject.Hooks.SecurityChecker
     # ],
-    
+
     # MCP servers (Tidewave is automatically configured for Phoenix projects)
     # mcp_servers: [:tidewave],
-    # 
+    #
     # You can also specify custom configuration like port:
     # mcp_servers: [
     #   {:tidewave, [port: 5000]}
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Claude.Install do
     # mcp_servers: [
     #   {:tidewave, [port: 4000, enabled?: false]}
     # ],
-    
+
     # Subagents provide specialized expertise with their own context
     # subagents: [
     #   %{
@@ -366,12 +366,7 @@ defmodule Mix.Tasks.Claude.Install do
   defp generate_hook_script(hook_module, claude_dep) do
     module_name = Module.split(hook_module) |> Enum.join(".")
 
-    deps =
-      if claude_dep == "{:claude, path: \"../..\"}" do
-        "[#{claude_dep}, {:jason, \"~> 1.4\"}, {:igniter, \"~> 0.6\"}]"
-      else
-        "[#{claude_dep}, {:jason, \"~> 1.4\"}]"
-      end
+    deps = "[#{claude_dep}, {:jason, \"~> 1.4\"}]"
 
     description =
       if function_exported?(hook_module, :description, 0) do
@@ -401,7 +396,7 @@ defmodule Mix.Tasks.Claude.Install do
 
   defp get_claude_dependency do
     if Mix.Project.get() == Claude.MixProject do
-      "{:claude, path: \"../..\"}"
+      "{:claude, path: \".\"}"
     else
       case get_claude_version_from_deps() do
         {:ok, version} -> "{:claude, \"#{version}\"}"


### PR DESCRIPTION
## Summary
- Fixed incorrect relative path in hook scripts that prevented them from working
- Removed unnecessary Igniter dependency from hook scripts
- Updated installer to generate correct paths for future installations

## Problem
The Claude Code hooks were not triggering automatically when files were edited because:
1. Hook scripts used incorrect relative path `../..` for the Claude dependency
2. Claude Code executes hooks from project root using `cd $CLAUDE_PROJECT_DIR && elixir .claude/hooks/script.exs`
3. This caused Mix.install to fail when looking for the Claude project

## Solution
- Changed path from `../..` to `.` in all hook scripts
- Removed Igniter dependency which was not needed by the hooks
- Fixed installer to generate correct paths for new installations
- Made hook scripts executable for better compatibility

## Test plan
- [x] Tested ElixirFormatter hook detects unformatted files
- [x] Verified hooks work without Igniter dependency
- [x] Confirmed installer generates correct paths

🤖 Generated with [Claude Code](https://claude.ai/code)