### PR TITLE
Add RelatedFiles hook to default installation

### DIFF
--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -183,6 +183,13 @@ defmodule Mix.Tasks.Claude.Install do
       :pre_tool_use,
       ["Bash"],
       "Validates code before git commits"
+    },
+    {
+      Claude.Hooks.PostToolUse.RelatedFiles,
+      ".claude/hooks/related_files.exs",
+      :post_tool_use,
+      ["Edit", "Write", "MultiEdit"],
+      "Suggests updating related test files when implementation files are modified"
     }
   ]
 
@@ -403,7 +410,8 @@ defmodule Mix.Tasks.Claude.Install do
       "mix claude hooks run",
       ".claude/hooks/elixir_formatter.exs",
       ".claude/hooks/compilation_checker.exs",
-      ".claude/hooks/pre_commit_check.exs"
+      ".claude/hooks/pre_commit_check.exs",
+      ".claude/hooks/related_files.exs"
     ]
 
     hooks_config


### PR DESCRIPTION
## Summary
- Added the RelatedFiles hook to the list of default hooks that get installed by `mix claude.install`
- The hook automatically suggests updating test files when implementation files are modified (and vice versa)
- Follows Elixir conventions for lib/test file mapping

## Changes
- Added RelatedFiles to `@available_hooks` in `lib/mix/tasks/claude.install.ex`
- Added cleanup pattern for `related_files.exs` in `remove_old_claude_hooks/1`
- Hook triggers on Edit, Write, and MultiEdit tool operations

## Test plan
- [x] Run `mix claude.install` to verify RelatedFiles hook is installed
- [x] Verify hook appears in `.claude/settings.json` 
- [x] Verify hook script is generated at `.claude/hooks/related_files.exs`
- [x] Test that modifying a lib file suggests updating the corresponding test file

🤖 Generated with [Claude Code](https://claude.ai/code)