### PR TITLE
Add .claude.exs to formatter configuration automatically

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: [".claude.exs", "{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -17,6 +17,7 @@ defmodule Mix.Tasks.Claude.Install do
   5. Generating any configured subagents for specialized assistance
   6. Configuring MCP servers (like Tidewave for Phoenix projects)
   7. Ensuring your project is properly configured for Claude Code integration
+  8. Adding .claude.exs to the formatter configuration for automatic formatting
 
   ## Example
 
@@ -26,6 +27,8 @@ defmodule Mix.Tasks.Claude.Install do
   """
 
   use Igniter.Mix.Task
+
+  @default_formatter_inputs ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 
   @meta_agent_config %{
     name: "Meta Agent",
@@ -239,7 +242,7 @@ defmodule Mix.Tasks.Claude.Install do
     default_formatter = """
     # Used by "mix format"
     [
-      inputs: [".claude.exs", "{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+      inputs: [".claude.exs" | #{inspect(@default_formatter_inputs)}]
     ]
     """
 
@@ -254,7 +257,7 @@ defmodule Mix.Tasks.Claude.Install do
           # Empty file - create the structure
           code =
             quote do
-              [inputs: [".claude.exs", "{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]]
+              [inputs: [".claude.exs" | unquote(@default_formatter_inputs)]]
             end
 
           {:ok, Igniter.Code.Common.add_code(zipper, code)}
@@ -265,7 +268,7 @@ defmodule Mix.Tasks.Claude.Install do
           |> Sourceror.Zipper.rightmost()
           |> Igniter.Code.Keyword.put_in_keyword(
             [:inputs],
-            ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+            @default_formatter_inputs,
             fn nested_zipper ->
               Igniter.Code.List.prepend_new_to_list(
                 nested_zipper,
@@ -284,7 +287,9 @@ defmodule Mix.Tasks.Claude.Install do
 
                Please add it manually to the inputs list:
 
-                   inputs: [".claude.exs", "{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+                   inputs: [".claude.exs" | #{inspect(@default_formatter_inputs)}]
+
+               Then run `mix format` to apply the formatting.
                """}
           end
       end

--- a/test/mix/tasks/claude.install_test.exs
+++ b/test/mix/tasks/claude.install_test.exs
@@ -9,6 +9,52 @@ defmodule Mix.Tasks.Claude.InstallTest do
       |> assert_creates(".claude.exs")
     end
 
+    test "adds .claude.exs to formatter inputs" do
+      igniter =
+        test_project(
+          files: %{
+            ".formatter.exs" => """
+            [
+              inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+            ]
+            """
+          }
+        )
+        |> Igniter.compose_task("claude.install")
+
+      assert_has_patch(igniter, ".formatter.exs", """
+        2   - |  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+          2 + |  inputs: [".claude.exs", "{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+      """)
+    end
+
+    test "handles missing .formatter.exs file" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("claude.install")
+
+      # Check that formatter content includes .claude.exs
+      source = Rewrite.source!(igniter.rewrite, ".formatter.exs")
+      content = Rewrite.Source.get(source, :content)
+      assert content =~ ~s|".claude.exs"|
+    end
+
+    test "formatter update is idempotent" do
+      igniter =
+        test_project(
+          files: %{
+            ".formatter.exs" => """
+            [
+              inputs: [".claude.exs", "{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+            ]
+            """
+          }
+        )
+        |> Igniter.compose_task("claude.install")
+
+      assert_unchanged(igniter, ".formatter.exs")
+    end
+
     test "creates CLAUDE.md through usage_rules.sync task" do
       igniter =
         test_project()

--- a/test/mix/tasks/claude.install_test.exs
+++ b/test/mix/tasks/claude.install_test.exs
@@ -307,7 +307,11 @@ defmodule Mix.Tasks.Claude.InstallTest do
       source = Rewrite.source!(igniter.rewrite, ".claude/agents/meta-agent.md")
       content = Rewrite.Source.get(source, :content)
       assert String.contains?(content, "name: meta-agent")
-      assert String.contains?(content, "description: Generates new, complete Claude Code subagent")
+
+      assert String.contains?(
+               content,
+               "description: Generates new, complete Claude Code subagent"
+             )
     end
 
     test "generates subagents with correct YAML frontmatter format" do
@@ -335,7 +339,8 @@ defmodule Mix.Tasks.Claude.InstallTest do
       content = Rewrite.Source.get(source, :content)
 
       # Verify YAML frontmatter format
-      assert content =~ ~r/^---\nname: test-agent\ndescription: A test agent for verification\ntools: Read, Grep\n---\n\n/
+      assert content =~
+               ~r/^---\nname: test-agent\ndescription: A test agent for verification\ntools: Read, Grep\n---\n\n/
 
       # Verify the prompt is included after the frontmatter
       assert content =~ "You are a test agent that helps with testing."
@@ -365,7 +370,9 @@ defmodule Mix.Tasks.Claude.InstallTest do
       content = Rewrite.Source.get(source, :content)
 
       # Verify YAML frontmatter format without tools line
-      assert content =~ ~r/^---\nname: no-tools-agent\ndescription: An agent with no tool restrictions\n---\n\n/
+      assert content =~
+               ~r/^---\nname: no-tools-agent\ndescription: An agent with no tool restrictions\n---\n\n/
+
       refute content =~ ~r/tools:/
     end
   end


### PR DESCRIPTION
## Summary
- Automatically adds `.claude.exs` to formatter inputs during `mix claude.install`
- Uses Igniter's AST manipulation for safe, idempotent updates
- Provides user-friendly warnings if automatic update fails

## Test plan
- [x] Run `mix claude.install` on a project without `.claude.exs` in formatter
- [x] Verify `.claude.exs` is added to the formatter inputs list
- [x] Run `mix format` and confirm it formats `.claude.exs` files
- [x] Run `mix claude.install` again to verify idempotency
- [x] Test error handling with malformed formatter files

## Details

This PR enhances the `mix claude.install` task to automatically configure the Elixir formatter to include `.claude.exs` files. This ensures that Claude configuration files are properly formatted alongside the rest of the codebase.

The implementation uses Igniter's AST manipulation capabilities to safely update the `.formatter.exs` file, following best practices:
- Proper error handling with user-friendly warnings
- Idempotent updates (won't duplicate entries)
- Handles edge cases like empty or missing formatter files

🤖 Generated with [Claude Code](https://claude.ai/code)