### PR TITLE
Fix PreCommitCheck hook exit code handling

### DIFF
--- a/.claude/hooks/pre_commit_check.exs
+++ b/.claude/hooks/pre_commit_check.exs
@@ -11,5 +11,5 @@ input = IO.read(:stdio, :eof)
 # Reuse the existing hook module
 case Claude.Hooks.PreToolUse.PreCommitCheck.run(input) do
   :ok -> System.halt(0)
-  _ -> System.halt(1)
+  {:error, _reason} -> System.halt(2)
 end

--- a/lib/claude/hooks/pre_tool_use/pre_commit_check.ex
+++ b/lib/claude/hooks/pre_tool_use/pre_commit_check.ex
@@ -17,7 +17,7 @@ defmodule Claude.Hooks.PreToolUse.PreCommitCheck do
 
   @impl Claude.Hooks.Hook.Behaviour
   def run(:eof) do
-    System.halt(0)
+    :ok
   end
 
   def run(json_input) when is_binary(json_input) do
@@ -27,7 +27,7 @@ defmodule Claude.Hooks.PreToolUse.PreCommitCheck do
 
       {:error, _} ->
         IO.puts(:stderr, "Failed to parse hook input JSON")
-        System.halt(1)
+        {:error, :invalid_json}
     end
   end
 
@@ -38,21 +38,14 @@ defmodule Claude.Hooks.PreToolUse.PreCommitCheck do
        when is_binary(command) do
     if String.contains?(command, "git commit") do
       IO.puts("Pre-commit validation triggered for: #{command}")
-
-      case validate_commit() do
-        :ok ->
-          System.halt(0)
-
-        {:error, _reason} ->
-          System.halt(2)
-      end
+      validate_commit()
     else
-      System.halt(0)
+      :ok
     end
   end
 
   defp handle_hook_input(_) do
-    System.halt(0)
+    :ok
   end
 
   defp validate_commit do

--- a/test/claude/hooks/post_tool_use/related_files_test.exs
+++ b/test/claude/hooks/post_tool_use/related_files_test.exs
@@ -113,7 +113,12 @@ defmodule Claude.Hooks.PostToolUse.RelatedFilesTest do
       {test_dir, cleanup} = setup_hook_test(compile: false)
 
       create_elixir_file(test_dir, "lib/my_app/user.ex", "defmodule MyApp.User do\nend")
-      create_elixir_file(test_dir, "test/my_app/user_test.exs", "defmodule MyApp.UserTest do\nend")
+
+      create_elixir_file(
+        test_dir,
+        "test/my_app/user_test.exs",
+        "defmodule MyApp.UserTest do\nend"
+      )
 
       json_input =
         build_tool_input(
@@ -138,7 +143,12 @@ defmodule Claude.Hooks.PostToolUse.RelatedFilesTest do
       {test_dir, cleanup} = setup_hook_test(compile: false)
 
       create_elixir_file(test_dir, "lib/my_app/user.ex", "defmodule MyApp.User do\nend")
-      create_elixir_file(test_dir, "test/my_app/user_test.exs", "defmodule MyApp.UserTest do\nend")
+
+      create_elixir_file(
+        test_dir,
+        "test/my_app/user_test.exs",
+        "defmodule MyApp.UserTest do\nend"
+      )
 
       json_input =
         build_tool_input(
@@ -162,8 +172,17 @@ defmodule Claude.Hooks.PostToolUse.RelatedFilesTest do
     test "handles nested directory structures" do
       {test_dir, cleanup} = setup_hook_test(compile: false)
 
-      create_elixir_file(test_dir, "lib/accounts/user.ex", "defmodule MyApp.Accounts.User do\nend")
-      create_elixir_file(test_dir, "test/accounts/user_test.exs", "defmodule MyApp.Accounts.UserTest do\nend")
+      create_elixir_file(
+        test_dir,
+        "lib/accounts/user.ex",
+        "defmodule MyApp.Accounts.User do\nend"
+      )
+
+      create_elixir_file(
+        test_dir,
+        "test/accounts/user_test.exs",
+        "defmodule MyApp.Accounts.UserTest do\nend"
+      )
 
       json_input =
         build_tool_input(
@@ -187,8 +206,17 @@ defmodule Claude.Hooks.PostToolUse.RelatedFilesTest do
     test "handles files with special characters in names" do
       {test_dir, cleanup} = setup_hook_test(compile: false)
 
-      create_elixir_file(test_dir, "lib/my_app/special-name.ex", "defmodule MyApp.SpecialName do\nend")
-      create_elixir_file(test_dir, "test/my_app/special-name_test.exs", "defmodule MyApp.SpecialNameTest do\nend")
+      create_elixir_file(
+        test_dir,
+        "lib/my_app/special-name.ex",
+        "defmodule MyApp.SpecialName do\nend"
+      )
+
+      create_elixir_file(
+        test_dir,
+        "test/my_app/special-name_test.exs",
+        "defmodule MyApp.SpecialNameTest do\nend"
+      )
 
       json_input =
         build_tool_input(
@@ -208,8 +236,6 @@ defmodule Claude.Hooks.PostToolUse.RelatedFilesTest do
 
       cleanup.()
     end
-
-
 
     test "does not suggest the same file being edited" do
       {test_dir, cleanup} = setup_hook_test(compile: false)
@@ -243,7 +269,12 @@ defmodule Claude.Hooks.PostToolUse.RelatedFilesTest do
       {test_dir, cleanup} = setup_hook_test(compile: false)
 
       create_elixir_file(test_dir, "lib/phoenix/channel.ex", "defmodule Phoenix.Channel do\nend")
-      create_elixir_file(test_dir, "test/phoenix/channel_test.exs", "defmodule Phoenix.ChannelTest do\nend")
+
+      create_elixir_file(
+        test_dir,
+        "test/phoenix/channel_test.exs",
+        "defmodule Phoenix.ChannelTest do\nend"
+      )
 
       json_input =
         build_tool_input(
@@ -293,6 +324,5 @@ defmodule Claude.Hooks.PostToolUse.RelatedFilesTest do
 
       assert RelatedFiles.run(json_input) == :ok
     end
-
   end
 end

--- a/test/mix/tasks/claude.install_test.exs
+++ b/test/mix/tasks/claude.install_test.exs
@@ -128,7 +128,7 @@ defmodule Mix.Tasks.Claude.InstallTest do
 
       # Now includes related_files by default from .claude.exs template
       assert length(post_tool_use_hooks) >= 2
-      
+
       hook_commands = Enum.map(post_tool_use_hooks, & &1["command"])
       assert Enum.any?(hook_commands, &String.contains?(&1, "elixir_formatter.exs"))
       assert Enum.any?(hook_commands, &String.contains?(&1, "compilation_checker.exs"))
@@ -630,7 +630,7 @@ defmodule Mix.Tasks.Claude.InstallTest do
       # New Claude hooks should be present
       assert Enum.any?(hook_commands, &String.contains?(&1, "elixir_formatter.exs"))
       assert Enum.any?(hook_commands, &String.contains?(&1, "compilation_checker.exs"))
-      
+
       # Test environment may include RelatedFiles if it's enabled in the project's .claude.exs
       # Just ensure we have at least the two required hooks
       assert length(hook_commands) >= 2
@@ -894,6 +894,7 @@ defmodule Mix.Tasks.Claude.InstallTest do
 
       # Settings should only contain valid hooks
       settings = File.read!(".claude/settings.json") |> Jason.decode!()
+
       all_commands =
         settings["hooks"]
         |> Map.values()


### PR DESCRIPTION
## Summary
- Fixed PreCommitCheck hook to properly block commits when validation fails
- Hook now returns values instead of calling System.halt() directly
- Wrapper script correctly propagates exit code 2 to block commits

## Problem
The PreCommitCheck hook was detecting issues but not actually blocking commits due to improper exit code handling. The hook module was calling `System.halt(2)` directly, which prevented the wrapper script from handling the exit code properly.

## Solution
Modified the hook module to return `:ok` or `{:error, reason}` values, and updated the wrapper script to handle these return values and exit with the appropriate code (2 for blocking).

## Test plan
- [x] Hook properly detects formatting issues
- [x] Hook properly detects compilation errors
- [x] Hook properly detects unused dependencies
- [x] Exit code 2 is returned when validation fails
- [x] Normal commands (non-commits) pass through without validation

Fixes #57

🤖 Generated with [Claude Code](https://claude.ai/code)