### PR TITLE
Include usage-rules directory in package files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Claude.MixProject do
         "GitHub" => "https://github.com/bradleygolden/claude"
       },
       maintainers: ["Bradley Golden"],
-      files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md usage-rules.md)
+      files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md usage-rules.md usage-rules)
     ]
   end
 


### PR DESCRIPTION
## Summary
- Add the `usage-rules` directory to the files list in mix.exs
- Ensures the usage-rules directory and its contents are included when publishing to Hex

## Test plan
- [ ] Verify that `mix hex.build` includes the usage-rules directory
- [ ] Check that all files in usage-rules/ are present in the generated package

🤖 Generated with [Claude Code](https://claude.ai/code)