### PR TITLE
Fix missing v0.2.2 version link in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ See the new updated [README.md](README.md) for more details!
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/bradleygolden/claude/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/bradleygolden/claude/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/bradleygolden/claude/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/bradleygolden/claude/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/bradleygolden/claude/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/bradleygolden/claude/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- Added the missing comparison link for v0.2.2 in CHANGELOG.md
- Updated the Unreleased link to compare from v0.2.2 instead of v0.2.1

## Test plan
- [x] Verified CHANGELOG.md links are properly formatted
- [x] Confirmed v0.2.2 link points to the correct comparison range
- [x] Ensured Unreleased link now compares from v0.2.2 to HEAD

🤖 Generated with [Claude Code](https://claude.ai/code)