### PR TITLE
Fix MCP server configuration to use .mcp.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New `mix claude.gen.hook` and `mix claude.gen.subagent` for code generation. See [documentation/generators.md](documentation/generators.md) for details.
 
+### Fixed
+
+- Output MCP server configuration to correct `.mcp.json` location instead of `.claude/settings.json`.
+
 ## [0.2.4] - 2025-08-01
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,12 +58,15 @@ mix claude.install
 # Hooks are executed automatically by Claude Code via the scripts in .claude/hooks/
 
 # MCP Server Management
-# MCP servers are configured directly in .claude.exs - see below
+# MCP servers are configured in .claude.exs and synced to .mcp.json
+# See https://docs.anthropic.com/en/docs/claude-code/mcp for details
 
 # MCP server configuration in .claude.exs supports:
 # - Simple atom format: :tidewave
 # - Custom port: {:tidewave, [port: 5000]}
 # - Disable without removing: {:tidewave, [port: 4000, enabled?: false]}
+
+# This creates a .mcp.json file with the proper MCP server configuration
 
 # Install via Igniter
 mix igniter.install claude
@@ -98,9 +101,9 @@ To reference claude code sub agents, please see @ai/anthropic/claude_code/build_
    - Ensures project-scoped configuration
 
 4. **MCP Server System** (`lib/claude/mcp/`)
-   - **Catalog** - Tidewave configuration for Phoenix projects
+   - **Config** - Manages .mcp.json file creation and updates
    - **Registry** - Reads mcp_servers from `.claude.exs` (supports both atom and tuple formats)
-   - **Installer** - Syncs MCP configuration to settings.json
+   - **Installer** - Syncs MCP configuration to .mcp.json (not settings.json)
    - **Automatic** - Tidewave is auto-configured for Phoenix projects
    - **Custom Config** - Supports port customization: `{:tidewave, [port: 5000]}`
    - **Enable/Disable** - Servers can be disabled with `enabled?: false` option

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Create specialized AI assistants with built-in best practices from your dependen
 → See [Sub-Agents Documentation](documentation/subagents.md) for details and examples.
 
 ### 🔌 **MCP Server Support**
-Integrate with Phoenix development tools via Tidewave. MCP servers are configured in `.claude.exs` and automatically synced to `.mcp.json`.
+Integrate with Phoenix development tools via Tidewave. MCP servers are configured in `.claude.exs` and synced to `.mcp.json` when you run `mix claude.install`.
 
 → See [Quickstart](documentation/quickstart.md#enable-more-features) for configuration.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Create specialized AI assistants with built-in best practices from your dependen
 → See [Sub-Agents Documentation](documentation/subagents.md) for details and examples.
 
 ### 🔌 **MCP Server Support**
-Integrate with Phoenix development tools via Tidewave.
+Integrate with Phoenix development tools via Tidewave. MCP servers are configured in `.claude.exs` and automatically synced to `.mcp.json`.
 
 → See [Quickstart](documentation/quickstart.md#enable-more-features) for configuration.
 

--- a/documentation/quickstart.md
+++ b/documentation/quickstart.md
@@ -128,7 +128,7 @@ You've just experienced Claude's core features:
 
 - **[Configure Additional Hooks](hooks.md)** - Enable related files suggestions and more
 - **[Create Sub-Agents](subagents.md)** - Build specialized AI assistants for your project
-- **Phoenix MCP Server** - Add `mcp_servers: [:tidewave]` to your `.claude.exs`
+- **Phoenix MCP Server** - Add `mcp_servers: [:tidewave]` to your `.claude.exs` (creates `.mcp.json` automatically)
 
 ### Learn More
 

--- a/lib/claude/mcp/config.ex
+++ b/lib/claude/mcp/config.ex
@@ -1,0 +1,143 @@
+defmodule Claude.MCP.Config do
+  @moduledoc """
+  Manages MCP server configuration in .mcp.json files.
+
+  MCP servers should be configured in .mcp.json at the project root,
+  not in settings.json. This module handles reading and writing
+  MCP configurations according to Claude Code standards.
+  """
+
+  @doc """
+  Writes MCP server configuration to .mcp.json file.
+  """
+  def write_mcp_config(igniter, servers) when is_list(servers) do
+    mcp_config = build_mcp_config(servers)
+
+    case mcp_config do
+      %{"mcpServers" => servers_map} when map_size(servers_map) > 0 ->
+        igniter
+        |> Igniter.create_or_update_file(
+          ".mcp.json",
+          Jason.encode!(mcp_config, pretty: true) <> "\n",
+          fn source ->
+            update_existing_mcp_config(source, servers)
+          end
+        )
+
+      _ ->
+        igniter
+    end
+  end
+
+  @doc """
+  Removes MCP server configuration from .mcp.json file.
+  """
+  def remove_mcp_server(igniter, server_name) when is_atom(server_name) do
+    remove_mcp_server(igniter, Atom.to_string(server_name))
+  end
+
+  def remove_mcp_server(igniter, server_name) when is_binary(server_name) do
+    if Igniter.exists?(igniter, ".mcp.json") do
+      igniter
+      |> Igniter.update_file(".mcp.json", fn source ->
+        content = Rewrite.Source.get(source, :content)
+
+        case Jason.decode(content) do
+          {:ok, %{"mcpServers" => servers} = config} ->
+            updated_servers = Map.delete(servers, server_name)
+
+            updated_config =
+              if map_size(updated_servers) == 0 do
+                %{"mcpServers" => %{}}
+              else
+                Map.put(config, "mcpServers", updated_servers)
+              end
+
+            new_content = Jason.encode!(updated_config, pretty: true) <> "\n"
+            Rewrite.Source.update(source, :content, new_content)
+
+          _ ->
+            source
+        end
+      end)
+    else
+      igniter
+    end
+  end
+
+  defp build_mcp_config(servers) do
+    mcp_servers =
+      servers
+      |> Enum.reduce(%{}, fn server, acc ->
+        case server do
+          :tidewave ->
+            Map.put(acc, "tidewave", tidewave_config(4000))
+
+          {:tidewave, opts} ->
+            if Keyword.get(opts, :enabled?, true) do
+              port = Keyword.get(opts, :port, 4000)
+              Map.put(acc, "tidewave", tidewave_config(port))
+            else
+              acc
+            end
+
+          {name, opts} when is_atom(name) ->
+            if Keyword.get(opts, :enabled?, true) do
+              Map.put(acc, Atom.to_string(name), build_server_config(name, opts))
+            else
+              acc
+            end
+
+          name when is_atom(name) ->
+            Map.put(acc, Atom.to_string(name), build_server_config(name, []))
+        end
+      end)
+
+    %{"mcpServers" => mcp_servers}
+  end
+
+  defp update_existing_mcp_config(source, servers) do
+    content = Rewrite.Source.get(source, :content)
+
+    case Jason.decode(content) do
+      {:ok, existing_config} ->
+        new_config = build_mcp_config(servers)
+
+        merged_servers =
+          existing_config
+          |> Map.get("mcpServers", %{})
+          |> Map.merge(new_config["mcpServers"])
+
+        updated_config = Map.put(existing_config, "mcpServers", merged_servers)
+        new_content = Jason.encode!(updated_config, pretty: true) <> "\n"
+        Rewrite.Source.update(source, :content, new_content)
+
+      {:error, _} ->
+        new_config = build_mcp_config(servers)
+        new_content = Jason.encode!(new_config, pretty: true) <> "\n"
+        Rewrite.Source.update(source, :content, new_content)
+    end
+  end
+
+  defp tidewave_config(port) do
+    %{
+      "type" => "sse",
+      "url" => "http://localhost:#{port}/tidewave/mcp"
+    }
+  end
+
+  defp build_server_config(name, opts) do
+    case name do
+      :tidewave ->
+        port = Keyword.get(opts, :port, 4000)
+        tidewave_config(port)
+
+      _ ->
+        %{
+          "command" => Atom.to_string(name),
+          "args" => [],
+          "env" => %{}
+        }
+    end
+  end
+end

--- a/lib/claude/mcp/config.ex
+++ b/lib/claude/mcp/config.ex
@@ -18,7 +18,7 @@ defmodule Claude.MCP.Config do
         igniter
         |> Igniter.create_or_update_file(
           ".mcp.json",
-          Jason.encode!(mcp_config, pretty: true) <> "\n",
+          encode_json(mcp_config),
           fn source ->
             update_existing_mcp_config(source, servers)
           end
@@ -53,7 +53,7 @@ defmodule Claude.MCP.Config do
                 Map.put(config, "mcpServers", updated_servers)
               end
 
-            new_content = Jason.encode!(updated_config, pretty: true) <> "\n"
+            new_content = encode_json(updated_config)
             Rewrite.Source.update(source, :content, new_content)
 
           _ ->
@@ -69,32 +69,26 @@ defmodule Claude.MCP.Config do
     mcp_servers =
       servers
       |> Enum.reduce(%{}, fn server, acc ->
-        case server do
-          :tidewave ->
-            Map.put(acc, "tidewave", tidewave_config(4000))
-
-          {:tidewave, opts} ->
-            if Keyword.get(opts, :enabled?, true) do
-              port = Keyword.get(opts, :port, 4000)
-              Map.put(acc, "tidewave", tidewave_config(port))
-            else
-              acc
-            end
-
-          {name, opts} when is_atom(name) ->
-            if Keyword.get(opts, :enabled?, true) do
-              Map.put(acc, Atom.to_string(name), build_server_config(name, opts))
-            else
-              acc
-            end
-
-          name when is_atom(name) ->
-            Map.put(acc, Atom.to_string(name), build_server_config(name, []))
-        end
+        process_server_config(server, acc)
       end)
 
     %{"mcpServers" => mcp_servers}
   end
+
+  defp process_server_config(server, acc) do
+    {name, opts} = normalize_server_config(server)
+
+    if Keyword.get(opts, :enabled?, true) do
+      Map.put(acc, Atom.to_string(name), build_server_config(name, opts))
+    else
+      acc
+    end
+  end
+
+  defp normalize_server_config(atom) when is_atom(atom), do: {atom, []}
+
+  defp normalize_server_config({name, opts} = config) when is_atom(name) and is_list(opts),
+    do: config
 
   defp update_existing_mcp_config(source, servers) do
     content = Rewrite.Source.get(source, :content)
@@ -109,12 +103,12 @@ defmodule Claude.MCP.Config do
           |> Map.merge(new_config["mcpServers"])
 
         updated_config = Map.put(existing_config, "mcpServers", merged_servers)
-        new_content = Jason.encode!(updated_config, pretty: true) <> "\n"
+        new_content = encode_json(updated_config)
         Rewrite.Source.update(source, :content, new_content)
 
       {:error, _} ->
         new_config = build_mcp_config(servers)
-        new_content = Jason.encode!(new_config, pretty: true) <> "\n"
+        new_content = encode_json(new_config)
         Rewrite.Source.update(source, :content, new_content)
     end
   end
@@ -126,18 +120,21 @@ defmodule Claude.MCP.Config do
     }
   end
 
-  defp build_server_config(name, opts) do
-    case name do
-      :tidewave ->
-        port = Keyword.get(opts, :port, 4000)
-        tidewave_config(port)
+  defp build_server_config(:tidewave, opts) do
+    port = Keyword.get(opts, :port, 4000)
+    tidewave_config(port)
+  end
 
-      _ ->
-        %{
-          "command" => Atom.to_string(name),
-          "args" => [],
-          "env" => %{}
-        }
-    end
+  defp build_server_config(name, _opts) do
+    # Generic fallback - would need to be customized per server
+    %{
+      "command" => Atom.to_string(name),
+      "args" => [],
+      "env" => %{}
+    }
+  end
+
+  defp encode_json(data) do
+    Jason.encode!(data, pretty: true) <> "\n"
   end
 end

--- a/lib/claude/mcp/config.ex
+++ b/lib/claude/mcp/config.ex
@@ -126,7 +126,6 @@ defmodule Claude.MCP.Config do
   end
 
   defp build_server_config(name, _opts) do
-    # Generic fallback - would need to be customized per server
     %{
       "command" => Atom.to_string(name),
       "args" => [],

--- a/lib/mix/tasks/claude.gen.subagent.ex
+++ b/lib/mix/tasks/claude.gen.subagent.ex
@@ -378,18 +378,21 @@ defmodule Mix.Tasks.Claude.Gen.Subagent do
       ",\n" <> indent <> "  description: " <> inspect(description)
     ]
 
-    parts = 
+    parts =
       if prompt do
-        parts ++ [
-          ",\n" <> indent <> "  prompt: \"\"\"\n" <>
-          indent_lines(escaped_prompt, indent <> "  ") <>
-          "\n" <> indent <> "  \"\"\""
-        ]
+        parts ++
+          [
+            ",\n" <>
+              indent <>
+              "  prompt: \"\"\"\n" <>
+              indent_lines(escaped_prompt, indent <> "  ") <>
+              "\n" <> indent <> "  \"\"\""
+          ]
       else
         parts
       end
 
-    parts = 
+    parts =
       if tools != [] do
         parts ++ [",\n" <> indent <> "  tools: " <> tools_str]
       else

--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -138,7 +138,6 @@ defmodule Mix.Tasks.Claude.Install do
     tools: [:write, :read, :edit, :multi_edit, :bash, :web_search]
   }
 
-  # @default_tidewave_port 4000 - no longer used
   @tidewave_setup_instructions """
   Tidewave integrates with your Phoenix application:
   1. Add to your deps in mix.exs: {:tidewave, "~> 0.2.0"}

--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -1086,6 +1086,10 @@ defmodule Mix.Tasks.Claude.Install do
       igniter = Igniter.include_existing_file(igniter, path)
       source = Rewrite.source!(igniter.rewrite, path)
       content = Rewrite.Source.get(source, :content)
+
+      # Security Note: Code.eval_string evaluates arbitrary Elixir code from user files.
+      # This is acceptable for development tooling where users control their own files.
+      # The evaluated code runs with the same permissions as the mix task.
       {result, _binding} = Code.eval_string(content, [], file: path)
       {:ok, result}
     rescue

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -159,7 +159,7 @@ Claude supports Model Context Protocol (MCP) servers, currently with built-in su
 
 ### Configuring MCP Servers
 
-MCP servers are configured in `.claude.exs`:
+MCP servers are configured in `.claude.exs` and automatically synced to `.mcp.json`:
 
 ```elixir
 %{
@@ -176,7 +176,9 @@ MCP servers are configured in `.claude.exs`:
 }
 ```
 
-**Note**: While only Tidewave is officially supported through the installer, you can manually add other MCP servers to your Claude settings.
+When you run `mix claude.install`, this configuration is automatically written to `.mcp.json` in the correct format for Claude Code to recognize. The `.mcp.json` file follows the [official MCP configuration format](https://docs.anthropic.com/en/docs/claude-code/mcp).
+
+**Note**: While only Tidewave is officially supported through the installer, you can manually add other MCP servers to `.mcp.json` following the Claude Code documentation.
 
 ## Sub-agents
 


### PR DESCRIPTION
## Summary

- Fixes MCP server configuration to write to `.mcp.json` instead of `settings.json`
- Implements correct SSE format for Tidewave servers
- Follows Claude Code's official MCP documentation

## Context

The current implementation incorrectly writes MCP server configuration to `.claude/settings.json`. According to Claude Code's official documentation, MCP servers should be defined in `.mcp.json` at the project root.

## Changes

### New Module
- Created `Claude.MCP.Config` module to manage `.mcp.json` file operations
- Handles creation, updates, and server removal
- Supports SSE format for Tidewave: `{"type": "sse", "url": "http://localhost:PORT/tidewave/mcp"}`

### Updated Install Task
- Replaced settings.json writing logic with new MCP config module
- Added `get_mcp_servers_config` to read from `.claude.exs`
- Added `add_mcp_notices` for user feedback
- Removed deprecated functions

### Tests
- Added tests for `.mcp.json` file creation
- Verified correct SSE format
- Tested custom port configuration
- Ensured disabled servers don't create files

### Documentation
- Updated CLAUDE.md, README.md, quickstart.md, and usage-rules.md
- Clarified that MCP config is synced to `.mcp.json`
- Added links to official Claude Code MCP documentation

## Test Plan

- [x] All existing tests pass
- [x] New tests verify `.mcp.json` creation
- [x] Manual testing with Phoenix project
- [x] Code compiles without warnings
- [x] Formatted with `mix format`

🤖 Generated with [Claude Code](https://claude.ai/code)