### PR TITLE
Update CHANGELOG.md to reflect v0.2.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New `mix claude.gen.hook` and `mix claude.gen.subagent` for code generation. See [documentation/generators.md](documentation/generators.md) for details.
 
+## [0.2.4] - 2025-08-01
+
 ### Fixed
 
 - Fixed a bug where hooks weren't configured properly which prevented them from being useful to claude claude code. Please run `mix claude.install` to sync the new settings and pull in the fix.
@@ -61,7 +63,8 @@ See the new updated [README.md](README.md) for more details!
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/bradleygolden/claude/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/bradleygolden/claude/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/bradleygolden/claude/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/bradleygolden/claude/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/bradleygolden/claude/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/bradleygolden/claude/compare/v0.2.0...v0.2.1


### PR DESCRIPTION
## Summary
- Updates the CHANGELOG.md on main branch to reflect the v0.2.4 patch release
- Moves the hook output fix from Unreleased to the new v0.2.4 section
- Updates comparison links

## Context
The v0.2.4 release was created from the v0.2 branch as a patch release containing only the critical hook output fix. This PR updates the main branch changelog to document this release.

🤖 Generated with [Claude Code](https://claude.ai/code)