### PR TITLE
Embed usage rules documentation directly in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,6 +355,36 @@ mix usage_rules.search_docs "Enum.zip" --query-by title
 ## igniter usage
 _A code generation and project patching framework_
 
-[igniter usage rules](deps/igniter/usage-rules.md)
+# Rules for working with Igniter
+
+## Understanding Igniter
+
+Igniter is a code generation and project patching framework that enables semantic manipulation of Elixir codebases. It provides tools for creating intelligent generators that can both create new files and modify existing ones safely. Igniter works with AST (Abstract Syntax Trees) through Sourceror.Zipper to make precise, context-aware changes to your code.
+
+## Available Modules
+
+### Project-Level Modules (`Igniter.Project.*`)
+
+- **`Igniter.Project.Application`** - Working with Application modules and application configuration
+- **`Igniter.Project.Config`** - Modifying Elixir config files (config.exs, runtime.exs, etc.)
+- **`Igniter.Project.Deps`** - Managing dependencies declared in mix.exs
+- **`Igniter.Project.Formatter`** - Interacting with .formatter.exs files
+- **`Igniter.Project.IgniterConfig`** - Managing .igniter.exs configuration files
+- **`Igniter.Project.MixProject`** - Updating project configuration in mix.exs
+- **`Igniter.Project.Module`** - Creating and managing modules with proper file placement
+- **`Igniter.Project.TaskAliases`** - Managing task aliases in mix.exs
+- **`Igniter.Project.Test`** - Working with test and test support files
+
+### Code-Level Modules (`Igniter.Code.*`)
+
+- **`Igniter.Code.Common`** - General purpose utilities for working with Sourceror.Zipper
+- **`Igniter.Code.Function`** - Working with function definitions and calls
+- **`Igniter.Code.Keyword`** - Manipulating keyword lists
+- **`Igniter.Code.List`** - Working with lists in AST
+- **`Igniter.Code.Map`** - Manipulating maps
+- **`Igniter.Code.Module`** - Working with module definitions and usage
+- **`Igniter.Code.String`** - Utilities for string literals
+- **`Igniter.Code.Tuple`** - Working with tuples
+
 <!-- igniter-end -->
 <!-- usage-rules-end -->

--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -767,11 +767,7 @@ defmodule Mix.Tasks.Claude.Install do
     igniter
     |> Igniter.add_task("usage_rules.sync", [
       "CLAUDE.md",
-      "--all",
-      "--inline",
-      "usage_rules:all",
-      "--link-to-folder",
-      "deps"
+      "--all"
     ])
     |> then(fn igniter_with_task ->
       if show_notice do


### PR DESCRIPTION
## Summary
- Modified the `sync_usage_rules` function in `lib/mix/tasks/claude.install.ex` to embed usage rules documentation directly in CLAUDE.md instead of linking to files in the deps folder
- Removed `--inline usage_rules:all` and `--link-to-folder deps` arguments from the `usage_rules.sync` command
- This improves accessibility by making usage rules documentation self-contained within CLAUDE.md

## Test plan
- [x] Verify that CLAUDE.md now contains embedded usage rules documentation instead of links
- [x] Confirm that the `usage_rules.sync` command arguments were properly modified
- [ ] Test that `mix claude.install` still works correctly with the new configuration
- [ ] Verify that usage rules are properly embedded when running the sync command

🤖 Generated with [Claude Code](https://claude.ai/code)