### PR TITLE
Optimize context window usage with reference links for usage rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-08-19
+
+### Changed
+
+**BREAKING CHANGE**: Root CLAUDE.md now uses reference links to usage rules instead of inlining content
+
+- Previously was a little overzealous pulling in all context into CLAUDE.md which resulted in this error: ⚠ Large CLAUDE.md will impact performance (...k chars > 40.0k)
+- Root CLAUDE.md now contains links to usage rules in `deps/` instead of inlining full content
+- Nested memory CLAUDE.md files continue to inline usage rules for focused context-specific guidance
+- Existing projects will get the optimized format on next `mix claude.install`
+
 ## [0.4.0] - 2025-08-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,168 +223,20 @@ usage rules to understand the correct patterns, conventions, and best practices.
 ## usage_rules usage
 _A dev tool for Elixir projects to gather LLM usage rules from dependencies_
 
-## Using Usage Rules
-
-Many packages have usage rules, which you should *thoroughly* consult before taking any
-action. These usage rules contain guidelines and rules *directly from the package authors*.
-They are your best source of knowledge for making decisions.
-
-## Modules & functions in the current app and dependencies
-
-When looking for docs for modules & functions that are dependencies of the current project,
-or for Elixir itself, use `mix usage_rules.docs`
-
-```
-# Search a whole module
-mix usage_rules.docs Enum
-
-# Search a specific function
-mix usage_rules.docs Enum.zip
-
-# Search a specific function & arity
-mix usage_rules.docs Enum.zip/1
-```
-
-
-## Searching Documentation
-
-You should also consult the documentation of any tools you are using, early and often. The best 
-way to accomplish this is to use the `usage_rules.search_docs` mix task. Once you have
-found what you are looking for, use the links in the search results to get more detail. For example:
-
-```
-# Search docs for all packages in the current application, including Elixir
-mix usage_rules.search_docs Enum.zip
-
-# Search docs for specific packages
-mix usage_rules.search_docs Req.get -p req
-
-# Search docs for multi-word queries
-mix usage_rules.search_docs "making requests" -p req
-
-# Search only in titles (useful for finding specific functions/modules)
-mix usage_rules.search_docs "Enum.zip" --query-by title
-```
-
-
+[usage_rules usage rules](deps/usage_rules/usage-rules.md)
 <!-- usage_rules-end -->
 <!-- usage_rules:elixir-start -->
 ## usage_rules:elixir usage
-# Elixir Core Usage Rules
-
-## Pattern Matching
-- Use pattern matching over conditional logic when possible
-- Prefer to match on function heads instead of using `if`/`else` or `case` in function bodies
-
-## Error Handling
-- Use `{:ok, result}` and `{:error, reason}` tuples for operations that can fail
-- Avoid raising exceptions for control flow
-- Use `with` for chaining operations that return `{:ok, _}` or `{:error, _}`
-
-## Common Mistakes to Avoid
-- Elixir has no `return` statement, nor early returns. The last expression in a block is always returned.
-- Don't use `Enum` functions on large collections when `Stream` is more appropriate
-- Avoid nested `case` statements - refactor to a single `case`, `with` or separate functions
-- Don't use `String.to_atom/1` on user input (memory leak risk)
-- Lists and enumerables cannot be indexed with brackets. Use pattern matching or `Enum` functions
-- Prefer `Enum` functions like `Enum.reduce` over recursion
-- When recursion is necessary, prefer to use pattern matching in function heads for base case detection
-- Using the process dictionary is typically a sign of unidiomatic code
-- Only use macros if explicitly requested
-- There are many useful standard library functions, prefer to use them where possible
-
-## Function Design
-- Use guard clauses: `when is_binary(name) and byte_size(name) > 0`
-- Prefer multiple function clauses over complex conditional logic
-- Name functions descriptively: `calculate_total_price/2` not `calc/2`
-- Predicate function names should not start with `is` and should end in a question mark. 
-- Names like `is_thing` should be reserved for guards
-
-## Data Structures
-- Use structs over maps when the shape is known: `defstruct [:name, :age]`
-- Prefer keyword lists for options: `[timeout: 5000, retries: 3]`
-- Use maps for dynamic key-value data
-- Prefer to prepend to lists `[new | list]` not `list ++ [new]`
-
-## Mix Tasks
-
-- Use `mix help` to list available mix tasks
-- Use `mix help task_name` to get docs for an individual task
-- Read the docs and options fully before using tasks
-
-## Testing
-- Run tests in a specific file with `mix test test/my_test.exs` and a specific test with the line number `mix test path/to/test.exs:123`
-- Limit the number of failed tests with `mix test --max-failures n`
-- Use `@tag` to tag specific tests, and `mix test --only tag` to run only those tests
-- Use `assert_raise` for testing expected exceptions: `assert_raise ArgumentError, fn -> invalid_function() end`
-- Use `mix help test` to for full documentation on running tests
-
-## Debugging
-
-- Use `dbg/1` to print values while debugging. This will display the formatted value and other relevant information in the console.
-
+[usage_rules:elixir usage rules](deps/usage_rules/usage-rules/elixir.md)
 <!-- usage_rules:elixir-end -->
 <!-- usage_rules:otp-start -->
 ## usage_rules:otp usage
-# OTP Usage Rules
-
-## GenServer Best Practices
-- Keep state simple and serializable
-- Handle all expected messages explicitly
-- Use `handle_continue/2` for post-init work
-- Implement proper cleanup in `terminate/2` when necessary
-
-## Process Communication
-- Use `GenServer.call/3` for synchronous requests expecting replies
-- Use `GenServer.cast/2` for fire-and-forget messages.
-- When in doubt, us `call` over `cast`, to ensure back-pressure
-- Set appropriate timeouts for `call/3` operations
-
-## Fault Tolerance
-- Set up processes such that they can handle crashing and being restarted by supervisors
-- Use `:max_restarts` and `:max_seconds` to prevent restart loops
-
-## Task and Async
-- Use `Task.Supervisor` for better fault tolerance
-- Handle task failures with `Task.yield/2` or `Task.shutdown/2`
-- Set appropriate task timeouts
-- Use `Task.async_stream/3` for concurrent enumeration with back-pressure
-
+[usage_rules:otp usage rules](deps/usage_rules/usage-rules/otp.md)
 <!-- usage_rules:otp-end -->
 <!-- igniter-start -->
 ## igniter usage
 _A code generation and project patching framework_
 
-# Rules for working with Igniter
-
-## Understanding Igniter
-
-Igniter is a code generation and project patching framework that enables semantic manipulation of Elixir codebases. It provides tools for creating intelligent generators that can both create new files and modify existing ones safely. Igniter works with AST (Abstract Syntax Trees) through Sourceror.Zipper to make precise, context-aware changes to your code.
-
-## Available Modules
-
-### Project-Level Modules (`Igniter.Project.*`)
-
-- **`Igniter.Project.Application`** - Working with Application modules and application configuration
-- **`Igniter.Project.Config`** - Modifying Elixir config files (config.exs, runtime.exs, etc.)
-- **`Igniter.Project.Deps`** - Managing dependencies declared in mix.exs
-- **`Igniter.Project.Formatter`** - Interacting with .formatter.exs files
-- **`Igniter.Project.IgniterConfig`** - Managing .igniter.exs configuration files
-- **`Igniter.Project.MixProject`** - Updating project configuration in mix.exs
-- **`Igniter.Project.Module`** - Creating and managing modules with proper file placement
-- **`Igniter.Project.TaskAliases`** - Managing task aliases in mix.exs
-- **`Igniter.Project.Test`** - Working with test and test support files
-
-### Code-Level Modules (`Igniter.Code.*`)
-
-- **`Igniter.Code.Common`** - General purpose utilities for working with Sourceror.Zipper
-- **`Igniter.Code.Function`** - Working with function definitions and calls
-- **`Igniter.Code.Keyword`** - Manipulating keyword lists
-- **`Igniter.Code.List`** - Working with lists in AST
-- **`Igniter.Code.Map`** - Manipulating maps
-- **`Igniter.Code.Module`** - Working with module definitions and usage
-- **`Igniter.Code.String`** - Utilities for string literals
-- **`Igniter.Code.Tuple`** - Working with tuples
-
+[igniter usage rules](deps/igniter/usage-rules.md)
 <!-- igniter-end -->
 <!-- usage-rules-end -->

--- a/documentation/guide-usage-rules.md
+++ b/documentation/guide-usage-rules.md
@@ -21,18 +21,18 @@ This ensures Claude Code follows the exact patterns and conventions that library
 When you run `mix claude.install`, Claude automatically runs:
 
 ```bash
-mix usage_rules.sync CLAUDE.md --all --inline usage_rules:all --link-to-folder deps
+mix usage_rules.sync CLAUDE.md --all --link-to-folder deps
 ```
 
 This command:
 - Gathers usage rules from all dependencies that provide them
-- Adds them inline to your `CLAUDE.md` file
-- Creates links to the source files in `deps/`
-- Ensures Claude Code always has access to current best practices
+- Creates links to the usage rules files in `deps/` instead of inlining content
+- Keeps your root `CLAUDE.md` file lean and reduces context window usage
+- Ensures Claude Code always has access to current best practices when needed
 
 ### In Your CLAUDE.md
 
-After installation, your `CLAUDE.md` will contain sections like:
+After installation, your `CLAUDE.md` will contain links to usage rules instead of full content:
 
 ```markdown
 ## ash usage
@@ -45,16 +45,13 @@ _Productive. Reliable. Fast._
 
 [phoenix usage rules](deps/phoenix/usage-rules.md)
 
-## usage_rules:elixir usage
-# Elixir Core Usage Rules
+## usage_rules usage
+_A dev tool for Elixir projects to gather LLM usage rules from dependencies_
 
-## Pattern Matching
-- Use pattern matching over conditional logic when possible
-- Prefer to match on function heads instead of using `if`/`else`
-...
+[usage_rules usage rules](deps/usage_rules/usage-rules.md)
 ```
 
-Claude Code reads this file at the start of every session, ensuring it follows these guidelines.
+This keeps the root CLAUDE.md file lean while Claude Code can still access the full usage rules when needed. For core Elixir rules and critical guidelines that are frequently referenced, some packages may still be inlined.
 
 ## Nested Memories
 
@@ -69,12 +66,13 @@ Claude supports distributing CLAUDE.md files across different directories in you
 }
 ```
 
-This creates separate `CLAUDE.md` files in each directory with the relevant usage rules:
-- `lib/my_app_web/CLAUDE.md` - Phoenix and Ash Phoenix integration rules for web code
-- `lib/my_app/accounts/CLAUDE.md` - Ash framework rules for business logic
+This creates separate `CLAUDE.md` files in each directory with the relevant usage rules inlined for focused context:
+- `lib/my_app_web/CLAUDE.md` - Phoenix and Ash Phoenix integration rules for web code (inlined)
+- `lib/my_app/accounts/CLAUDE.md` - Ash framework rules for business logic (inlined)
 
 Benefits of nested memories:
 - **Context-aware guidance** - Different rules for different parts of your codebase
+- **Inlined for focus** - Nested memory files have rules inlined since they're context-specific
 - **Reduced noise** - Claude only sees relevant rules for the current context
 - **Better organization** - Keep domain-specific guidance with the code
 

--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -814,7 +814,9 @@ defmodule Mix.Tasks.Claude.Install do
     igniter
     |> Igniter.add_task("usage_rules.sync", [
       "CLAUDE.md",
-      "--all"
+      "--all",
+      "--link-to-folder",
+      "deps"
     ])
     |> then(fn igniter_with_task ->
       if show_notice do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Claude.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   @elixir_version "~> 1.18"
   @description "Batteries-included Claude Code integration for Elixir projects"
 


### PR DESCRIPTION
## Summary

This PR optimizes context window usage by changing how usage rules are included in the root CLAUDE.md file.

**BREAKING CHANGE**: Root CLAUDE.md now uses reference links instead of inlining full usage rules content.

## Changes

- **Root CLAUDE.md**: Now contains links to `deps/package_name/usage-rules.md` instead of inlining thousands of lines
- **Nested memories**: Continue to inline usage rules for focused, context-specific guidance  
- **Version bump**: 0.4.0 → 0.5.0 (minor bump for breaking change)
- **Documentation**: Updated to reflect new reference link behavior

## Problem Solved

Previously, projects with many dependencies would get this warning:
```
⚠ Large CLAUDE.md will impact performance (...k chars > 40.0k)
```

The root CLAUDE.md could contain thousands of lines of inlined usage rules, consuming significant context window space.

## Solution

- Root CLAUDE.md: Reference links (lean, reduced context usage)
- Nested memories: Inline rules (focused, context-specific)
- No configuration needed - opinionated best practice

## Test Plan

- [x] All existing tests pass (222/222)
- [x] Compilation succeeds with warnings as errors
- [x] CLAUDE.md demonstrates new format with reference links
- [x] Documentation updated to reflect changes

## Impact

- **Dramatic context window reduction** for root CLAUDE.md
- **Maintained performance** for nested memory files  
- **Automatic upgrade** on next `mix claude.install`
- **No user configuration** required

🤖 Generated with [Claude Code](https://claude.ai/code)