### PR TITLE
Update CHANGELOG.md to reflect v0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - @reference system with URL caching for documentation references in nested memories
 
+## [0.5.1] - 2025-08-22
+
 ### Changed
 - Stop and subagent_stop hooks now use `blocking?: false` by default to prevent infinite loops
 - When compilation or formatting fails in stop hooks, they now provide informational feedback without blocking Claude


### PR DESCRIPTION
## Summary
- Move v0.5.1 release notes from Unreleased section to proper v0.5.1 section
- Keep @reference system in Unreleased since it hasn't been released yet
- Only include the stop hooks infinite loop fix in v0.5.1

🤖 Generated with [Claude Code](https://claude.ai/code)