### PR TITLE
Fix hook wrapper plugin configuration loading

### DIFF
--- a/.claude/hooks/wrapper.exs
+++ b/.claude/hooks/wrapper.exs
@@ -18,17 +18,13 @@ defmodule ClaudeHookWrapper do
   end
 
   defp load_claude_config() do
-    config_path = ".claude.exs"
-
-    if File.exists?(config_path) do
-      try do
-        {config, _} = Code.eval_file(config_path)
-        config
-      rescue
-        _ -> %{}
+    try do
+      case Claude.Config.read() do
+        {:ok, config} -> config
+        {:error, _reason} -> %{}
       end
-    else
-      %{}
+    rescue
+      _ -> %{}
     end
   end
 

--- a/priv/claude_hook_wrapper.exs
+++ b/priv/claude_hook_wrapper.exs
@@ -18,17 +18,13 @@ defmodule ClaudeHookWrapper do
   end
 
   defp load_claude_config() do
-    config_path = ".claude.exs"
-
-    if File.exists?(config_path) do
-      try do
-        {config, _} = Code.eval_file(config_path)
-        config
-      rescue
-        _ -> %{}
+    try do
+      case Claude.Config.read() do
+        {:ok, config} -> config
+        {:error, _reason} -> %{}
       end
-    else
-      %{}
+    rescue
+      _ -> %{}
     end
   end
 


### PR DESCRIPTION
## Summary

- Fixed hook wrapper to properly load plugin configurations using `Claude.Config.read()`
- Updated both template (`priv/claude_hook_wrapper.exs`) and installed (`.claude/hooks/wrapper.exs`) versions

## Problem

The hook wrapper was loading `.claude.exs` directly with `Code.eval_file()`, which bypassed the plugin system. This prevented plugin configurations like `auto_install_deps?: true` from the `Claude.Plugins.Worktrees` plugin from working correctly.

## Solution

Changed the `load_claude_config()` function to use `Claude.Config.read()` instead of direct file loading. This ensures that:
- Plugins are properly loaded and processed
- Plugin configurations like `auto_install_deps?` work as expected
- The configuration system remains consistent across the codebase

## Test plan

- [x] All existing tests pass (324 tests, 0 failures)
- [x] Auto-install dependencies feature now works correctly with the Worktrees plugin
- [x] Verified both template and installed hook wrapper files are updated

🤖 Generated with [Claude Code](https://claude.ai/code)