### PR TITLE
Register all hook events when reporters are configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - @reference system with URL caching for documentation references in nested memories
 - Plugin system for extending .claude.exs configuration with reusable modules
+- Register all hook events when reporters are configured for complete observability
 
 ### Fixed
 - Webhook reporters now correctly receive hook events during execution

--- a/test/support/test_plugins.ex
+++ b/test/support/test_plugins.ex
@@ -110,4 +110,19 @@ defmodule TestPlugins do
       raise "Intentional failure for testing"
     end
   end
+
+  defmodule WithReporters do
+    @behaviour Claude.Plugin
+
+    def config(_opts) do
+      %{
+        reporters: [
+          {:webhook, url: "https://example.com/plugin-webhook"}
+        ],
+        hooks: %{
+          stop: [:compile]
+        }
+      }
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- When reporters are configured in `.claude.exs`, all hook events are now registered for complete observability
- Maintains backward compatibility: existing configurations without reporters work unchanged
- Added comprehensive test coverage for all scenarios

## Changes
- **Detection**: Check for `:reporters` key presence in `.claude.exs` 
- **All Events**: When reporters present, register all 8 hook events (PreToolUse, PostToolUse, Stop, SubagentStop, UserPromptSubmit, Notification, PreCompact, SessionStart)
- **Backward Compatible**: When no reporters, only register events with actual hooks (existing behavior)
- **Tests**: Added 7 test scenarios covering various reporter configurations

## Benefits
- **Complete Observability**: Reporters now receive all hook events for logging/monitoring
- **Zero Breaking Changes**: Existing setups continue to work identically
- **Clean Implementation**: Simple check for reporters key existence

## Test Plan
- [x] All existing tests pass
- [x] New tests validate reporter integration scenarios
- [x] Manual verification with/without reporters configured
- [x] Backward compatibility confirmed

🤖 Generated with [Claude Code](https://claude.ai/code)