### PR TITLE
Add weekly Claude sync workflow

### DIFF
--- a/.github/workflows/claude-sync.yml
+++ b/.github/workflows/claude-sync.yml
@@ -31,7 +31,17 @@ jobs:
     - name: Sync Claude
       run: mix claude.install --yes
       
+    - name: Check for changes
+      id: changes
+      run: |
+        if git diff --quiet; then
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+        fi
+      
     - name: Create Pull Request
+      if: steps.changes.outputs.has_changes == 'true'
       uses: peter-evans/create-pull-request@v5
       with:
         commit-message: "Weekly Claude sync"

--- a/.github/workflows/claude-sync.yml
+++ b/.github/workflows/claude-sync.yml
@@ -1,0 +1,44 @@
+name: Claude Sync
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Run every Monday at 9 AM UTC
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1
+      with:
+        otp-version: '27'
+        elixir-version: '1.18'
+
+    - name: Install dependencies
+      run: |
+        mix local.hex --force
+        mix local.rebar --force
+        mix deps.get
+
+    - name: Sync Claude
+      run: mix claude.install --yes
+      
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        commit-message: "Weekly Claude sync"
+        title: "Weekly Claude sync"
+        body: |
+          Weekly automated sync of Claude configuration.
+          
+          This PR was created automatically by running `mix claude.install --yes`.
+        branch: claude-sync-${{ github.run_number }}
+        delete-branch: true


### PR DESCRIPTION
## Summary
• Adds automated weekly workflow to sync Claude configuration
• Runs `mix claude.install --yes` every Monday at 9 AM UTC  
• Creates PR for review when changes are detected

## Test plan
- [x] Workflow file created with proper syntax
- [ ] Test workflow execution (will run on next Monday or via manual trigger)

🤖 Generated with [Claude Code](https://claude.ai/code)