### PR TITLE
Add Credo plugin with configurable strictness and auto-installation

### DIFF
--- a/lib/claude/plugins/credo.ex
+++ b/lib/claude/plugins/credo.ex
@@ -1,0 +1,60 @@
+defmodule Claude.Plugins.Credo do
+  @moduledoc """
+  Credo plugin for Claude Code providing code quality and static analysis support.
+
+  This plugin automatically configures Claude Code for Credo-enabled projects by:
+
+  * **Smart Detection**: Automatically activates when Credo dependency is detected
+  * **Configurable Strictness**: Control whether to run Credo in strict mode
+
+  ## Usage
+
+  Add to your `.claude.exs`:
+
+      %{
+        plugins: [Claude.Plugins.Credo]
+      }
+
+  Or with options:
+
+      %{
+        plugins: [{Claude.Plugins.Credo, strict?: true}]
+      }
+
+  The plugin will automatically activate when a `:credo` dependency is detected in `mix.exs`.
+
+  ## Options
+
+  * `:strict?` - Whether to run Credo in strict mode (default: `false`)
+  """
+
+  @behaviour Claude.Plugin
+
+  @impl Claude.Plugin
+  def config(opts) do
+    igniter = Keyword.get(opts, :igniter)
+    strict? = Keyword.get(opts, :strict?, false)
+
+    if detect_credo_project?(igniter) do
+      strict_flag = if strict?, do: " --strict", else: ""
+      credo_command = "credo#{strict_flag} {{tool_input.file_path}}"
+
+      %{
+        hooks: %{
+          post_tool_use: [
+            {credo_command, when: [:write, :edit, :multi_edit]}
+          ],
+          pre_tool_use: [
+            {credo_command, when: "Bash", command: ~r/^git commit/}
+          ]
+        }
+      }
+    else
+      %{}
+    end
+  end
+
+  defp detect_credo_project?(igniter) do
+    Igniter.Project.Deps.has_dep?(igniter, :credo)
+  end
+end


### PR DESCRIPTION
## Summary

- Add new Credo plugin for automatic code quality checks
- Auto-detects Credo dependency and configures hooks
- Includes configurable strict mode option
- Adds automatic plugin installation to claude.install task

## Changes

### New Credo Plugin (`lib/claude/plugins/credo.ex`)
- **Smart Detection**: Automatically activates when `:credo` dependency is detected
- **Dual Hooks**: Runs on both file edits (post_tool_use) and git commits (pre_tool_use) 
- **Configurable Strictness**: Optional `strict?: true` option runs `credo --strict`
- **Clean Implementation**: Uses string interpolation for command building

### Auto-Installation (`lib/mix/tasks/claude.install.ex`)
- Detects Credo dependency and automatically adds `Claude.Plugins.Credo`
- Follows same pattern as Phoenix and Ash plugin auto-installation
- Updates both `ensure_credo_plugin/2` function and default plugin list

## Usage

**Default (auto-detected):**
```elixir
%{
  plugins: [Claude.Plugins.Credo]  # Added automatically by claude.install
}
```

**With strict mode:**
```elixir
%{
  plugins: [{Claude.Plugins.Credo, strict?: true}]
}
```

## Test plan

- [x] Plugin compiles without warnings
- [x] Auto-detection works with Credo dependency
- [x] Hooks generate correct commands (with/without --strict)
- [x] Auto-installation adds plugin when Credo detected
- [x] Follows established plugin patterns and conventions

🤖 Generated with [Claude Code](https://claude.ai/code)