### PR TITLE
Add Phoenix server awareness feature

### DIFF
--- a/lib/mix/tasks/claude.phoenix.check.ex
+++ b/lib/mix/tasks/claude.phoenix.check.ex
@@ -1,0 +1,55 @@
+defmodule Mix.Tasks.Claude.Phoenix.Check do
+  @moduledoc """
+  Checks if Phoenix server is running by calling Endpoint.url().
+
+  If the endpoint is running, it will return the URL. If not, it will
+  fail silently. This gives Claude context about running servers.
+
+  ## Usage
+
+      mix claude.phoenix.check MyAppWeb.Endpoint
+  """
+
+  use Mix.Task
+
+  @shortdoc "Detects running Phoenix servers"
+
+  def run([endpoint_str]) do
+    Mix.Task.run("loadpaths")
+    endpoint = Module.concat([endpoint_str])
+
+    try do
+      url = endpoint.url()
+
+      IO.puts("""
+      <phoenix_server_status>
+      Server: #{inspect(endpoint)}
+      Status: RUNNING
+      URL: #{url}
+      </phoenix_server_status>
+
+      <instructions>
+      The Phoenix server is currently running at #{url}. Here's what you should do:
+
+      PRESERVE the running server - Do not kill or restart it because:
+        - The developer has hot code reloading active
+        - LiveView connections would be interrupted
+        - Current application state would be lost
+      </instructions>
+
+      <context>
+      This check ran automatically when your session started to prevent accidental
+      server restarts. The endpoint module #{inspect(endpoint)} successfully responded,
+      confirming the server is healthy and accepting requests.
+      </context>
+      """)
+    rescue
+      _ -> :ok
+    end
+  end
+
+  def run(_) do
+    IO.puts(:stderr, "Usage: mix claude.phoenix.check <EndpointModule>")
+    System.halt(1)
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds a Phoenix server awareness feature that prevents Claude Code from unnecessarily restarting running Phoenix servers.

## Problem
Claude Code doesn't know when a Phoenix server is already running, leading to:
- Interrupted development flow when Claude kills running servers
- Lost application state
- Broken LiveView connections
- Unnecessary server restarts

## Solution
The Phoenix plugin now includes a `:server_check` option that detects running servers on session start and provides context to Claude.

## Implementation
- New Mix task `claude.phoenix.check` that uses `Endpoint.url()` to detect running servers
- Simple, reliable check - if `url()` works, the server is running
- Structured output using XML tags following Claude 4 best practices
- Clear instructions to preserve running servers

## Usage
In `.claude.exs`:
```elixir
{Claude.Plugins.Phoenix, server_check: MyAppWeb.Endpoint}
```

## Benefits
- Preserves hot code reloading
- Maintains LiveView connections
- Keeps application state intact
- Better developer experience with Claude Code

## Test Plan
- [ ] Configure a Phoenix project with the `:server_check` option
- [ ] Start Phoenix server with `mix phx.server`
- [ ] Start Claude Code session and verify it detects the running server
- [ ] Confirm Claude doesn't attempt to restart the server
- [ ] Test with server not running to ensure silent failure