### PR TITLE
Ensure optional deps available during tests

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,9 @@
 ExUnit.start()
 
+for app <- [:req, :pythonx, :igniter] do
+  Application.ensure_all_started(app)
+end
+
 Mimic.copy(Mix.Task)
 Mimic.copy(System)
 Mimic.copy(File)


### PR DESCRIPTION
## Summary
- start optional dependencies so tests run with required apps
- stub filesystem failure in JSONL reporter test for consistent results

## Testing
- `mix test`


------
https://chatgpt.com/codex/tasks/task_e_68c06fa1de888330a7b5693a41ab17f3