### PR TITLE
Fix cache refresh time logic

### DIFF
--- a/lib/claude/documentation/cache.ex
+++ b/lib/claude/documentation/cache.ex
@@ -87,11 +87,14 @@ defmodule Claude.Documentation.Cache do
 
     if File.exists?(resolved_path) do
       stat = File.stat!(resolved_path)
-      mtime_seconds = :calendar.datetime_to_gregorian_seconds(stat.mtime)
-      unix_epoch_seconds = :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
-      unix_timestamp = mtime_seconds - unix_epoch_seconds
 
-      mtime_datetime = DateTime.from_unix!(unix_timestamp)
+      mtime =
+        case stat.mtime do
+          %NaiveDateTime{} = naive -> naive
+          erl -> NaiveDateTime.from_erl!(erl)
+        end
+
+      mtime_datetime = DateTime.from_naive!(mtime, "Etc/UTC")
       age_hours = DateTime.diff(DateTime.utc_now(), mtime_datetime, :hour)
       age_hours > max_age_hours
     else

--- a/test/claude/documentation/cache_test.exs
+++ b/test/claude/documentation/cache_test.exs
@@ -144,6 +144,21 @@ defmodule Claude.Documentation.CacheTest do
 
       assert Cache.needs_refresh?(fresh_file, 24) == false
     end
+
+    test "returns true for stale files when max_age_hours is small", %{cache_dir: cache_dir} do
+      stale_file = Path.join(cache_dir, "stale.md")
+      File.write!(stale_file, "stale content")
+
+      old_time =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-2 * 3600)
+        |> NaiveDateTime.truncate(:second)
+        |> NaiveDateTime.to_erl()
+
+      File.touch(stale_file, old_time)
+
+      assert Cache.needs_refresh?(stale_file, 1) == true
+    end
   end
 
   describe "list_cached_docs/1" do


### PR DESCRIPTION
## Summary
- simplify `needs_refresh?/2` by converting file mtime with `DateTime.from_naive!/2`
- test fresh cache files do not require refresh
- test stale cache files trigger refresh when max age is low

## Testing
- `mix test test/claude/documentation/cache_test.exs`


------
https://chatgpt.com/codex/tasks/task_e_68c1a3e98234833095c1458b9d309fb3