### PR TITLE
Fix date handling in JSONL reporter

### DIFF
--- a/lib/claude/hooks/reporters/jsonl.ex
+++ b/lib/claude/hooks/reporters/jsonl.ex
@@ -126,7 +126,7 @@ defmodule Claude.Hooks.Reporters.Jsonl do
 
   defp expand_filename_pattern(pattern) do
     now = DateTime.utc_now()
-    date = Date.to_iso8601(now)
+    date = now |> DateTime.to_date() |> Date.to_iso8601()
 
     datetime =
       DateTime.to_iso8601(now)

--- a/test/claude/hooks/reporters/jsonl_test.exs
+++ b/test/claude/hooks/reporters/jsonl_test.exs
@@ -113,6 +113,18 @@ defmodule Claude.Hooks.Reporters.JsonlTest do
       end)
     end
 
+    test "creates events file with default options" do
+      with_temp_dir(fn temp_dir ->
+        File.cd!(temp_dir, fn ->
+          assert Jsonl.report(@sample_event_data, []) == :ok
+
+          today = Date.utc_today() |> Date.to_iso8601()
+          expected_file = ".claude/logs/events-#{today}.jsonl"
+          assert File.exists?(expected_file)
+        end)
+      end)
+    end
+
     test "expands filename patterns correctly" do
       with_temp_dir(fn temp_dir ->
         opts = [


### PR DESCRIPTION
## Summary
- ensure JSONL reporter gets date from DateTime properly
- add coverage for default log file creation

## Testing
- `mix test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a3ef21d083309be76695869cf786