### PR TITLE
Add server check option for Phoenix plugin

### DIFF
--- a/lib/claude/plugins/phoenix.ex
+++ b/lib/claude/plugins/phoenix.ex
@@ -30,6 +30,9 @@ defmodule Claude.Plugins.Phoenix do
   * `:include_daisyui?` - Whether to include DaisyUI component library documentation (default: `true`)
   * `:port` - Default port for Tidewave MCP server (default: `4000`). Environment variable `PORT` will still override this.
   * `:tidewave_enabled?` - Whether to enable Tidewave MCP server configuration (default: `true`)
+  * `:server_check` - Endpoint module to check for running server. Can be:
+    - `false` or `nil` - Disabled (default)
+    - Module atom (e.g., `MyAppWeb.Endpoint`) - Check if this endpoint is running
 
   ## Phoenix Version Support
 
@@ -51,16 +54,33 @@ defmodule Claude.Plugins.Phoenix do
     include_daisyui? = Keyword.get(opts, :include_daisyui?, true)
     port = Keyword.get(opts, :port, 4000)
     tidewave_enabled? = Keyword.get(opts, :tidewave_enabled?, true)
+    server_check = Keyword.get(opts, :server_check, false)
 
-    if detect_phoenix_project?(igniter) and tidewave_enabled? do
+    if detect_phoenix_project?(igniter) do
       app_name = get_app_name(igniter)
       phoenix_version = get_phoenix_version()
 
-      %{
-        mcp_servers: [tidewave: [port: "${PORT:-#{port}}"]],
-        nested_memories:
+      base_config = %{}
+
+      base_config =
+        if tidewave_enabled? do
+          Map.put(base_config, :mcp_servers, tidewave: [port: "${PORT:-#{port}}"])
+        else
+          base_config
+        end
+
+      base_config =
+        Map.put(
+          base_config,
+          :nested_memories,
           build_nested_memories(igniter, app_name, phoenix_version, include_daisyui?)
-      }
+        )
+
+      if server_check do
+        Map.put(base_config, :hooks, build_server_check_hooks(server_check))
+      else
+        base_config
+      end
     else
       %{}
     end
@@ -164,5 +184,19 @@ defmodule Claude.Plugins.Phoenix do
     else
       []
     end
+  end
+
+  defp build_server_check_hooks(server_check) do
+    check_command = build_server_check_command(server_check)
+
+    %{
+      session_start: [
+        {check_command, when: [:startup, :resume, :clear, :compact]}
+      ]
+    }
+  end
+
+  defp build_server_check_command(server_check) when is_atom(server_check) do
+    "claude.phoenix.check #{inspect(server_check)}"
   end
 end

--- a/lib/mix/tasks/claude.phoenix.check.ex
+++ b/lib/mix/tasks/claude.phoenix.check.ex
@@ -1,0 +1,109 @@
+defmodule Mix.Tasks.Claude.Phoenix.Check do
+  @moduledoc """
+  Checks if a Phoenix endpoint is reachable by making an HTTP request to its URL.
+
+  The task performs a `HEAD` request using the [Req](https://hex.pm/packages/req)
+  HTTP client. If `Req` is not available, the task raises with installation
+  instructions. Connection failures or timeouts are treated as "not running" and
+  produce no output. This gives Claude context about running servers while
+  avoiding false positives from configuration-only checks.
+
+  ## Usage
+
+      mix claude.phoenix.check MyAppWeb.Endpoint
+  """
+
+  use Mix.Task
+
+  @shortdoc "Detects running Phoenix servers"
+
+  def run([endpoint_str]) do
+    Mix.Task.run("loadpaths")
+    endpoint = Module.concat([endpoint_str])
+
+    case endpoint_status(endpoint) do
+      {:ok, url} ->
+        IO.puts("""
+        <phoenix_server_status>
+        Server: #{inspect(endpoint)}
+        Status: RUNNING
+        URL: #{url}
+        </phoenix_server_status>
+
+        <instructions>
+        The Phoenix server is currently running at #{url}. Here's what you should do:
+
+        PRESERVE the running server - Do not kill or restart it because:
+          - The developer has hot code reloading active
+          - LiveView connections would be interrupted
+          - Current application state would be lost
+        </instructions>
+
+        <context>
+        This check ran automatically when your session started to prevent accidental
+        server restarts. The endpoint module #{inspect(endpoint)} successfully responded,
+        confirming the server is healthy and accepting requests.
+        </context>
+        """)
+
+      {:error, :undefined_function} ->
+        :ok
+
+      {:error, :not_running} ->
+        :ok
+
+      {:error, reason} ->
+        Mix.shell().error("Phoenix server check failed: #{inspect(reason)}")
+        :ok
+    end
+  end
+
+  def run(_) do
+    IO.puts(:stderr, "Usage: mix claude.phoenix.check <EndpointModule>")
+    System.halt(1)
+  end
+
+  defp endpoint_status(endpoint) do
+    url = endpoint.url()
+
+    if server_running?(url) do
+      {:ok, url}
+    else
+      {:error, :not_running}
+    end
+  rescue
+    _e in UndefinedFunctionError ->
+      {:error, :undefined_function}
+
+    e ->
+      {:error, e}
+  end
+
+  @doc false
+  def server_running?(url) do
+    unless Code.ensure_loaded?(Req) do
+      Mix.raise("Req is not available. Add {:req, \"~> 0.5\"} to your dependencies.")
+    end
+
+    {:ok, _} = Application.ensure_all_started(:req)
+
+    req_opts =
+      [receive_timeout: 1_000, retry: false, max_retries: 0]
+      |> Keyword.merge(Application.get_env(:claude, :phoenix_check_req_options, []))
+
+    case Req.head(url, req_opts) do
+      {:ok, %Req.Response{status: status}} when status < 400 ->
+        true
+
+      {:ok, _} ->
+        false
+
+      {:error, %Req.TransportError{}} ->
+        false
+
+      {:error, reason} ->
+        Mix.shell().error("Req error: #{inspect(reason)}")
+        false
+    end
+  end
+end

--- a/test/claude/plugins/phoenix_test.exs
+++ b/test/claude/plugins/phoenix_test.exs
@@ -158,4 +158,29 @@ defmodule Claude.Plugins.PhoenixTest do
       refute daisyui_entry in web_memories
     end
   end
+
+  describe "config/1 - tidewave option" do
+    test "returns config without mcp_servers when tidewave disabled" do
+      igniter = phx_test_project()
+      result = Phoenix.config(igniter: igniter, tidewave_enabled?: false)
+
+      refute Map.has_key?(result, :mcp_servers)
+      assert Map.has_key?(result, :nested_memories)
+    end
+  end
+
+  describe "config/1 - server check option" do
+    test "includes server check hook when provided" do
+      igniter = phx_test_project()
+      result = Phoenix.config(igniter: igniter, server_check: MyAppWeb.Endpoint)
+
+      expected = %{
+        session_start: [
+          {"claude.phoenix.check MyAppWeb.Endpoint", when: [:startup, :resume, :clear, :compact]}
+        ]
+      }
+
+      assert result.hooks == expected
+    end
+  end
 end

--- a/test/mix/tasks/claude_phoenix_check_test.exs
+++ b/test/mix/tasks/claude_phoenix_check_test.exs
@@ -1,0 +1,28 @@
+defmodule Mix.Tasks.Claude.Phoenix.CheckTest do
+  use Claude.ClaudeCodeCase, async: false
+
+  setup do
+    test_name = :"test_#{System.unique_integer([:positive])}"
+    Application.put_env(:claude, :phoenix_check_req_options, plug: {Req.Test, test_name})
+    on_exit(fn -> Application.delete_env(:claude, :phoenix_check_req_options) end)
+    {:ok, test_name: test_name}
+  end
+
+  test "server_running?/1 returns true when request succeeds", %{test_name: test_name} do
+    Req.Test.stub(test_name, fn conn -> Plug.Conn.send_resp(conn, 200, "ok") end)
+
+    owner = self()
+    Req.Test.allow(test_name, owner, self())
+
+    assert Mix.Tasks.Claude.Phoenix.Check.server_running?("http://example.com")
+  end
+
+  test "server_running?/1 returns false on transport error", %{test_name: test_name} do
+    Req.Test.stub(test_name, &Req.Test.transport_error(&1, :econnrefused))
+
+    owner = self()
+    Req.Test.allow(test_name, owner, self())
+
+    refute Mix.Tasks.Claude.Phoenix.Check.server_running?("http://example.com")
+  end
+end


### PR DESCRIPTION
## Summary
- use Req to perform a HEAD request for `mix claude.phoenix.check`
- raise helpful message when Req is missing and log unexpected request errors
- test server checker with Req.Test stubs

## Testing
- `mix compile --warnings-as-errors`
- `mix test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a409e140833099a14048a6cd03a2