### PR TITLE
Allow plugins to inline usage rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - @reference system with URL caching for documentation references in nested memories
 - Plugin system for extending .claude.exs configuration with reusable modules
 - Register all hook events when reporters are configured for complete observability
+- Plugins can specify `inline_usage_rules` to embed selected packages in the root CLAUDE.md (Phoenix and Ash plugins inline their core rules)
 
 ### Changed
 - Stop and subagent_stop hooks removed from default configuration (opt-in only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - @reference system with URL caching for documentation references in nested memories
 - Plugin system for extending .claude.exs configuration with reusable modules
 - Register all hook events when reporters are configured for complete observability
-- Plugins can specify `inline_usage_rules` to embed selected packages in the root CLAUDE.md (Phoenix and Ash plugins inline their core rules)
+- Root CLAUDE.md now always inlines `usage_rules:all`; plugins can specify `inline_usage_rules` to embed additional packages (Phoenix and Ash plugins inline their core rules)
 
 ### Changed
 - Stop and subagent_stop hooks removed from default configuration (opt-in only)

--- a/documentation/guide-usage-rules.md
+++ b/documentation/guide-usage-rules.md
@@ -21,14 +21,18 @@ This ensures Claude Code follows the exact patterns and conventions that library
 When you run `mix claude.install`, Claude automatically runs:
 
 ```bash
-mix usage_rules.sync CLAUDE.md --all --link-to-folder deps
+mix usage_rules.sync CLAUDE.md --all --link-to-folder deps --inline phoenix,ash
 ```
 
 This command:
 - Gathers usage rules from all dependencies that provide them
 - Creates links to the usage rules files in `deps/` instead of inlining content
+- Inlines core rules for selected packages (here Phoenix and Ash) while linking others
 - Keeps your root `CLAUDE.md` file lean and reduces context window usage
 - Ensures Claude Code always has access to current best practices when needed
+
+Plugins can configure which packages are always inlined. For example, the Phoenix and Ash plugins
+embed their core rules directly while keeping other dependency rules referenced.
 
 ### In Your CLAUDE.md
 

--- a/documentation/guide-usage-rules.md
+++ b/documentation/guide-usage-rules.md
@@ -21,18 +21,17 @@ This ensures Claude Code follows the exact patterns and conventions that library
 When you run `mix claude.install`, Claude automatically runs:
 
 ```bash
-mix usage_rules.sync CLAUDE.md --all --link-to-folder deps --inline phoenix,ash
+mix usage_rules.sync CLAUDE.md --all --link-to-folder deps --inline usage_rules:all,phoenix,ash
 ```
 
 This command:
 - Gathers usage rules from all dependencies that provide them
 - Creates links to the usage rules files in `deps/` instead of inlining content
-- Inlines core rules for selected packages (here Phoenix and Ash) while linking others
+- Inlines the base rules from `usage_rules:all` plus core rules for selected packages (here Phoenix and Ash) while linking others
 - Keeps your root `CLAUDE.md` file lean and reduces context window usage
 - Ensures Claude Code always has access to current best practices when needed
 
-Plugins can configure which packages are always inlined. For example, the Phoenix and Ash plugins
-embed their core rules directly while keeping other dependency rules referenced.
+Plugins can configure which packages are always inlined. Claude always embeds `usage_rules:all`, and plugins like Phoenix and Ash add their core rules while keeping other dependency rules referenced.
 
 ### In Your CLAUDE.md
 

--- a/lib/claude/plugins/ash.ex
+++ b/lib/claude/plugins/ash.ex
@@ -55,7 +55,8 @@ defmodule Claude.Plugins.Ash do
             {"ash.codegen --check", when: [:write, :edit, :multi_edit]}
           ]
         },
-        nested_memories: build_nested_memories(igniter, app_name)
+        nested_memories: build_nested_memories(igniter, app_name),
+        inline_usage_rules: ["ash"]
       }
     else
       %{}

--- a/lib/claude/plugins/phoenix.ex
+++ b/lib/claude/plugins/phoenix.ex
@@ -59,7 +59,8 @@ defmodule Claude.Plugins.Phoenix do
       %{
         mcp_servers: [tidewave: [port: "${PORT:-#{port}}"]],
         nested_memories:
-          build_nested_memories(igniter, app_name, phoenix_version, include_daisyui?)
+          build_nested_memories(igniter, app_name, phoenix_version, include_daisyui?),
+        inline_usage_rules: ["phoenix"]
       }
     else
       %{}

--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -808,6 +808,7 @@ defmodule Mix.Tasks.Claude.Install do
 
   defp get_inline_usage_rules(igniter) do
     claude_exs_path = igniter.assigns[:claude_exs_path]
+
     inline_from_config =
       if Igniter.exists?(igniter, claude_exs_path) do
         case read_config_with_plugins(igniter, claude_exs_path) do

--- a/lib/mix/tasks/claude.install.ex
+++ b/lib/mix/tasks/claude.install.ex
@@ -779,14 +779,24 @@ defmodule Mix.Tasks.Claude.Install do
 
   defp sync_usage_rules(igniter) do
     show_notice = !Igniter.exists?(igniter, "CLAUDE.md")
+    inline_rules = get_inline_usage_rules(igniter)
 
-    igniter
-    |> Igniter.add_task("usage_rules.sync", [
+    base_args = [
       "CLAUDE.md",
       "--all",
       "--link-to-folder",
       "deps"
-    ])
+    ]
+
+    args =
+      if inline_rules == [] do
+        base_args
+      else
+        base_args ++ ["--inline", Enum.join(inline_rules, ",")]
+      end
+
+    igniter
+    |> Igniter.add_task("usage_rules.sync", args)
     |> then(fn igniter_with_task ->
       if show_notice do
         igniter_with_task
@@ -799,6 +809,22 @@ defmodule Mix.Tasks.Claude.Install do
         igniter_with_task
       end
     end)
+  end
+
+  defp get_inline_usage_rules(igniter) do
+    claude_exs_path = igniter.assigns[:claude_exs_path]
+
+    if Igniter.exists?(igniter, claude_exs_path) do
+      case read_config_with_plugins(igniter, claude_exs_path) do
+        {:ok, config} when is_map(config) ->
+          Map.get(config, :inline_usage_rules, [])
+
+        _ ->
+          []
+      end
+    else
+      []
+    end
   end
 
   defp generate_nested_memories(igniter) do

--- a/test/claude/plugins/ash_test.exs
+++ b/test/claude/plugins/ash_test.exs
@@ -19,6 +19,13 @@ defmodule Claude.Plugins.AshTest do
 
       assert result == %{}
     end
+
+    test "config includes inline_usage_rules for ash" do
+      igniter = ash_test_project()
+      result = Ash.config(igniter: igniter)
+
+      assert result.inline_usage_rules == ["ash"]
+    end
   end
 
   describe "config/1 - hooks configuration" do

--- a/test/claude/plugins/phoenix_test.exs
+++ b/test/claude/plugins/phoenix_test.exs
@@ -88,6 +88,13 @@ defmodule Claude.Plugins.PhoenixTest do
       assert "phoenix:html" in web_memories
       assert "phoenix:elixir" in web_memories
     end
+
+    test "config includes inline_usage_rules for phoenix" do
+      igniter = phx_test_project()
+      result = Phoenix.config(igniter: igniter)
+
+      assert result.inline_usage_rules == ["phoenix"]
+    end
   end
 
   describe "config/1 - version detection with custom mix.lock" do

--- a/test/mix/tasks/claude.install_test.exs
+++ b/test/mix/tasks/claude.install_test.exs
@@ -2118,6 +2118,7 @@ defmodule Mix.Tasks.Claude.InstallTest do
       igniter =
         phx_ash_test_project()
         |> Igniter.compose_task("claude.install")
+
       {"usage_rules.sync", args} =
         Enum.find(igniter.tasks, fn {task, _} -> task == "usage_rules.sync" end)
 

--- a/test/mix/tasks/claude.install_test.exs
+++ b/test/mix/tasks/claude.install_test.exs
@@ -2098,6 +2098,21 @@ defmodule Mix.Tasks.Claude.InstallTest do
       assert String.contains?(content, "Claude.Plugins.Ash")
     end
 
+    test "usage rules for Phoenix and Ash are inlined" do
+      igniter =
+        phx_ash_test_project()
+        |> Igniter.compose_task("claude.install")
+
+      assert Enum.any?(igniter.tasks, fn
+               {"usage_rules.sync", args} ->
+                 "--inline" in args &&
+                   Enum.any?(args, &(&1 in ["phoenix,ash", "ash,phoenix"]))
+
+               _ ->
+                 false
+             end)
+    end
+
     test "Ash plugin detected during initial template creation" do
       igniter =
         ash_test_project()


### PR DESCRIPTION
## Summary
- let plugins declare `inline_usage_rules` to embed selected packages during `claude.install`
- Phoenix and Ash plugins now inline their core usage rules
- document inline usage rule support and note in changelog

## Testing
- `mix test test/claude/plugins/phoenix_test.exs test/claude/plugins/ash_test.exs test/mix/tasks/claude.install_test.exs`


------
https://chatgpt.com/codex/tasks/task_e_68c1b1365e648330bddcccfb398c4412