### PR TITLE
Fix dialyzer errors by adding Mix and ExUnit to PLT

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule Claude.MixProject do
       description: @description,
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      docs: docs()
+      docs: docs(),
+      dialyzer: dialyzer()
     ]
   end
 
@@ -56,6 +57,12 @@ defmodule Claude.MixProject do
       maintainers: ["Bradley Golden"],
       files:
         ~w(lib priv .formatter.exs mix.exs documentation/guide-quickstart.md documentation/guide-hooks.md documentation/guide-mcp.md documentation/guide-usage-rules.md README.md LICENSE CHANGELOG.md usage-rules.md usage-rules)
+    ]
+  end
+
+  defp dialyzer do
+    [
+      plt_add_apps: [:mix, :ex_unit]
     ]
   end
 


### PR DESCRIPTION
## Summary
- Adds dialyzer configuration to include `:mix` and `:ex_unit` in the PLT
- Resolves all dialyzer warnings about missing Mix.Task callbacks and unknown Mix module functions

## Problem
Running `mix dialyzer` was failing with errors like:
- `Callback info about the Mix.Task behaviour is not available`
- `Function Mix.Task.run/1 does not exist`
- `Function Mix.Project.umbrella?/0 does not exist`

These errors occurred because Mix.Task modules require Mix to be in the PLT for proper type checking.

## Solution
Added a `dialyzer/0` function in `mix.exs` that configures dialyzer to include `:mix` and `:ex_unit` in the PLT (Persistent Lookup Table).

## Test plan
- [x] Run `mix dialyzer` - passes with no errors
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)